### PR TITLE
Updated use of ClientIdentification to impl getPrincipal API

### DIFF
--- a/crud/src/main/java/com/redhat/lightblue/rest/crud/hystrix/AbstractRestCommand.java
+++ b/crud/src/main/java/com/redhat/lightblue/rest/crud/hystrix/AbstractRestCommand.java
@@ -108,10 +108,15 @@ public abstract class AbstractRestCommand extends HystrixCommand<String> {
 
     protected void addCallerId(Request req) {
         req.setClientId(new ClientIdentification() {
+            @Override
             public boolean isUserInRole(String role) {
                 return httpServletRequest == null ? false : httpServletRequest.isUserInRole(role);
             }
 
+            @Override
+            public String getPrincipal() {
+                return httpServletRequest.getUserPrincipal() != null ? httpServletRequest.getUserPrincipal().getName() : null;
+            }
         });
     }
 }

--- a/metadata/src/main/java/com/redhat/lightblue/rest/metadata/hystrix/AbstractRestCommand.java
+++ b/metadata/src/main/java/com/redhat/lightblue/rest/metadata/hystrix/AbstractRestCommand.java
@@ -96,6 +96,11 @@ public abstract class AbstractRestCommand extends HystrixCommand<String> {
             public boolean isUserInRole(String role) {
                 return httpServletRequest == null ? false : httpServletRequest.isUserInRole(role);
             }
+
+            @Override
+            public String getPrincipal() {
+                return httpServletRequest.getUserPrincipal() != null ? httpServletRequest.getUserPrincipal().getName() : null;
+            }
         });
     }
 }


### PR DESCRIPTION
Fixes use of ClientIdentification which is changed in lightblue-platform/ligthblue-core#132

NOTES:
- This PR will NOT build until the referenced PR is merged!!
- This PR will be required for lightblue-rest to build after lightblue-platform/ligthblue-core#132 is merged.
