### PR TITLE
Add alternate insert operation path for consistency (fixes #20)

### DIFF
--- a/crud/src/main/java/com/redhat/lightblue/rest/crud/AbstractCrudResource.java
+++ b/crud/src/main/java/com/redhat/lightblue/rest/crud/AbstractCrudResource.java
@@ -68,7 +68,7 @@ public abstract class AbstractCrudResource {
     @Path("/{entity}")
     @Deprecated
     public String insertAlt(@PathParam(PARAM_ENTITY) String entity,
-                                String request) {
+                            String request) {
         return insert(entity, null, request);
     }
 
@@ -79,8 +79,8 @@ public abstract class AbstractCrudResource {
     @Path("/{entity}/{version}")
     @Deprecated
     public String insertAlt(@PathParam(PARAM_ENTITY) String entity,
-                                @PathParam(PARAM_VERSION) String version,
-                                String request) {
+                            @PathParam(PARAM_VERSION) String version,
+                            String request) {
         return insert(entity, version, request);
     }
 


### PR DESCRIPTION
Alternatively, could simply add regex to the path to allow for an optional /insert segment. But I thought this was a little uglier than just adding new methods.
