### PR TITLE
Fixes #42: Revert projection of objectType in unit tests 

### DIFF
--- a/crud/src/test/java/com/redhat/lightblue/rest/crud/ITCaseCrudResourceTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/rest/crud/ITCaseCrudResourceTest.java
@@ -241,7 +241,7 @@ public class ITCaseCrudResourceTest {
                 "country",
                 "1.0.0",
                 "iso2code:CA,QE;iso2code:CA;iso2code:CA,EN",
-                "name:1r,iso3code:1,iso2code:0r,objectType:1",
+                "name:1r,iso3code:1,iso2code:0r",
                 "name:a,iso3code:d,iso2code:d",
                 0,
                 -1);

--- a/crud/src/test/resources/resultFound.json
+++ b/crud/src/test/resources/resultFound.json
@@ -12,8 +12,5 @@
     }, {
         "field": "iso3code",
         "include": true
-    }, {
-        "field": "objectType",
-        "include": true
     }]
 }

--- a/crud/src/test/resources/resultInserted.json
+++ b/crud/src/test/resources/resultInserted.json
@@ -4,8 +4,7 @@
     "data": [{
         "name": "Canad",
         "iso2code": "CA",
-        "iso3code": "CAN",
-        "objectType": "country"
+        "iso3code": "CAN"
     }],
     "projection": [{
         "field": "*",


### PR DESCRIPTION
This reverts commit 1fea5d05d51f246f76169ee96d98c8e7e2c08fb5.
