### PR TITLE
Bump audit hook dependency to 1.3.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses />.
             <dependency>
                 <groupId>com.redhat.lightblue.hook</groupId>
                 <artifactId>audit</artifactId>
-                <version>1.2.0-SNAPSHOT</version>
+                <version>1.3.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
This resolves Arquillian dependency resolution issues.