### PR TITLE
Add resource filtering to overlay projects

### DIFF
--- a/crud-basic-auth/pom.xml
+++ b/crud-basic-auth/pom.xml
@@ -33,6 +33,12 @@
                             <artifactId>lightblue-rest-crud</artifactId>
                         </overlay>
                     </overlays>
+                    <webResources>
+                      <resource>
+                          <directory>src/main/webapp</directory>
+                          <filtering>true</filtering>
+                      </resource>
+                    </webResources>
                 </configuration>
             </plugin>
         </plugins>

--- a/crud-cert-auth/pom.xml
+++ b/crud-cert-auth/pom.xml
@@ -41,6 +41,12 @@
                           </excludes>
                       </overlay>
                   </overlays>
+                  <webResources>
+                    <resource>
+                        <directory>src/main/webapp</directory>
+                        <filtering>true</filtering>
+                    </resource>
+                  </webResources>
               </configuration>
           </plugin>
       </plugins>

--- a/metadata-basic-auth/pom.xml
+++ b/metadata-basic-auth/pom.xml
@@ -33,6 +33,12 @@
                             <artifactId>lightblue-rest-metadata</artifactId>
                         </overlay>
                     </overlays>
+                    <webResources>
+                      <resource>
+                          <directory>src/main/webapp</directory>
+                          <filtering>true</filtering>
+                      </resource>
+                    </webResources>
                 </configuration>
             </plugin>
         </plugins>

--- a/metadata-cert-auth/pom.xml
+++ b/metadata-cert-auth/pom.xml
@@ -41,6 +41,12 @@
                           </excludes>
                       </overlay>
                   </overlays>
+                  <webResources>
+                    <resource>
+                        <directory>src/main/webapp</directory>
+                        <filtering>true</filtering>
+                    </resource>
+                  </webResources>
               </configuration>
           </plugin>
       </plugins>


### PR DESCRIPTION
So that version is returned from version servlet.  It seems these don't propagate down when pulled in via overlay