### PR TITLE
make audit-hooks available at run time

### DIFF
--- a/crud/pom.xml
+++ b/crud/pom.xml
@@ -90,11 +90,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
         </dependency>
-        <dependency>
-            <groupId>com.redhat.lightblue.hook</groupId>
-            <artifactId>lightblue-audit-hook</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
lightblue-audit-hook is listed twice, with the second instance using the test scope. lightblue-audit-hook should be available at runtime also.