### PR TITLE
Creating InitialLdapContext only once to improve authz performance

### DIFF
--- a/auth/src/main/java/com/redhat/lightblue/rest/auth/LightblueRoleProvider.java
+++ b/auth/src/main/java/com/redhat/lightblue/rest/auth/LightblueRoleProvider.java
@@ -24,10 +24,4 @@ public interface LightblueRoleProvider {
 
     public Collection<String> getUserRoles(String userName);
 
-    public Collection<String> getUsersInGroup(String groupName);
-
-    public void flushRoleCache(String roleName);
-
-    public void flushUserCache(String userName);
-
 }

--- a/auth/src/main/java/com/redhat/lightblue/rest/auth/jboss/CertLdapLoginModule.java
+++ b/auth/src/main/java/com/redhat/lightblue/rest/auth/jboss/CertLdapLoginModule.java
@@ -103,7 +103,7 @@ public class CertLdapLoginModule extends BaseCertLoginModule {
                 // lazy init
                 initializeLightblueLdapRoleProvider();
 
-            LOGGER.info("Prinicipal username:" + getUsername());
+            LOGGER.debug("Prinicipal username:" + getUsername());
 
             LdapName name = new LdapName(getUsername());
             String searchName = "";
@@ -125,14 +125,14 @@ public class CertLdapLoginModule extends BaseCertLoginModule {
                 userRoles.addMember(role);
             }
 
-            if (ACCESS_LOGGER.isInfoEnabled()) {
-                ACCESS_LOGGER.info("Principal username: " + getUsername() + ", roles: " + Arrays.toString(groupNames.toArray()));
+            if (ACCESS_LOGGER.isDebugEnabled()) {
+                ACCESS_LOGGER.debug("Principal username: " + getUsername() + ", roles: " + Arrays.toString(groupNames.toArray()));
             }
 
             LOGGER.debug("Assign principal [" + p.getName() + "] to role [" + roleName + "]");
         } catch (Exception e) {
             String principalName = p == null ? "null" : p.getName();
-            LOGGER.info("Failed to assign principal [" + principalName + "] to role [" + roleName + "]", e);
+            LOGGER.error("Failed to assign principal [" + principalName + "] to role [" + roleName + "]", e);
         }
         Group[] roleSets = {userRoles};
         return roleSets;

--- a/auth/src/main/java/com/redhat/lightblue/rest/auth/jboss/CertLdapLoginModule.java
+++ b/auth/src/main/java/com/redhat/lightblue/rest/auth/jboss/CertLdapLoginModule.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 
+import javax.naming.NamingException;
 import javax.naming.ldap.LdapName;
 import javax.naming.ldap.Rdn;
 import javax.security.auth.Subject;
@@ -39,6 +40,7 @@ import org.jboss.security.auth.spi.BaseCertLoginModule;
 
 import com.redhat.lightblue.rest.auth.LightblueRoleProvider;
 import com.redhat.lightblue.rest.auth.ldap.LightblueLdapRoleProvider;
+
 import org.slf4j.LoggerFactory;
 
 /**
@@ -61,6 +63,13 @@ public class CertLdapLoginModule extends BaseCertLoginModule {
     
     private static final Logger ACCESS_LOGGER = Logger.getLogger(CertLdapLoginModule.class, "access");
 
+    // LightblueRoleProvider singleton
+    private static LightblueRoleProvider lbLdap = null;
+
+    public CertLdapLoginModule() {
+
+    }
+
     @Override
 	public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String,?> sharedState, Map<String,?> options) {
         LOGGER.debug("CertLdapLoginModule#initialize was invoked");
@@ -68,23 +77,31 @@ public class CertLdapLoginModule extends BaseCertLoginModule {
 		super.initialize(subject, callbackHandler, sharedState, options);
 	}
     
+    public void initializeLightblueLdapRoleProvider() throws NamingException {
+        String ldapServer = (String) options.get(LDAP_SERVER);
+        String searchBase = (String) options.get(SEARCH_BASE);
+        String bindDn = (String) options.get(BIND_DN);
+        String bindPwd = (String) options.get(BIND_PWD);
+
+        lbLdap = new LightblueLdapRoleProvider(ldapServer, searchBase, bindDn, bindPwd);
+    }
+
     /* (non-Javadoc)
      * @see org.jboss.security.auth.spi.AbstractServerLoginModule#getRoleSets()
      */
     @Override
     protected Group[] getRoleSets() throws LoginException {
         LOGGER.debug("staticRoleLoginModule getRoleSets()");
+
         String roleName = (String) options.get(AUTH_ROLE_NAME);
-        String ldapServer = (String) options.get(LDAP_SERVER);
-        String searchBase = (String) options.get(SEARCH_BASE);
-        String bindDn = (String) options.get(BIND_DN);
-        String bindPwd = (String) options.get(BIND_PWD);
 
         SimpleGroup userRoles = new SimpleGroup("Roles");
 
         Principal p = null;
         try {
-            LightblueRoleProvider lbLdap = new LightblueLdapRoleProvider(ldapServer, searchBase, bindDn, bindPwd);
+            if (lbLdap == null)
+                // lazy init
+                initializeLightblueLdapRoleProvider();
 
             LOGGER.info("Prinicipal username:" + getUsername());
 

--- a/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/CachedLdapFindUserRolesByUidCommand.java
+++ b/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/CachedLdapFindUserRolesByUidCommand.java
@@ -42,7 +42,7 @@ public class CachedLdapFindUserRolesByUidCommand extends HystrixCommand<List<Str
     public CachedLdapFindUserRolesByUidCommand(LdapContext ldapContext, String ldapSearchBase, String uid) {
         super(HystrixCommand.Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey(GROUPKEY)).
                 andCommandKey(HystrixCommandKey.Factory.asKey(GROUPKEY + ":" + CachedLdapFindUserRolesByUidCommand.class.getSimpleName())));
-        LOGGER.debug("Creating LdapFindUserByUidCommand");
+        LOGGER.debug("Creating CachedLdapFindUserRolesByUidCommand");
         //check if the informed parameters are valid
         if (Strings.isNullOrEmpty(uid)) {
             LOGGER.error("uid informed in LdapFindUserByUidCommand constructor is empty or null");
@@ -59,7 +59,7 @@ public class CachedLdapFindUserRolesByUidCommand extends HystrixCommand<List<Str
 
     @Override
     protected List<String> run() throws Exception {
-        LOGGER.debug("LdapFindUserByUidCommand#run was invoked");
+        LOGGER.debug("CachedLdapFindUserRolesByUidCommand#run was invoked");
 
         List<String> roles = RolesCache.get(ldapQuery.uid);
 

--- a/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/LightblueLdapRoleProvider.java
+++ b/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/LightblueLdapRoleProvider.java
@@ -19,7 +19,6 @@
 package com.redhat.lightblue.rest.auth.ldap;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Hashtable;
 import java.util.List;
 
@@ -33,7 +32,17 @@ import org.slf4j.LoggerFactory;
 
 import com.netflix.hystrix.exception.HystrixRuntimeException;
 import com.redhat.lightblue.rest.auth.LightblueRoleProvider;
+import com.redhat.lightblue.rest.authz.RolesCache;
 
+/**
+ * Fetches user roles from ldap. Results are cached (see {@link RolesCache}).
+ *
+ * Initialization of this class is quite expensive due to the cost of ldap jndi lookup (@link {@link InitialLdapContext} init).
+ * Use it as a singleton.
+ *
+ * @author mpatercz
+ *
+ */
 public class LightblueLdapRoleProvider implements LightblueRoleProvider {
     private final Logger LOGGER = LoggerFactory.getLogger(LightblueLdapRoleProvider.class);
 

--- a/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/LightblueLdapRoleProvider.java
+++ b/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/LightblueLdapRoleProvider.java
@@ -83,25 +83,4 @@ public class LightblueLdapRoleProvider implements LightblueRoleProvider {
         return userRoles;
     }
 
-    @Override
-    public Collection<String> getUsersInGroup(String groupName) {
-        LOGGER.error("Invoking LightblueLdapRoleProvider#getUsersInGroup (not supported))");
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public void flushRoleCache(String roleName) {
-        LOGGER.error("Invoking LightblueLdapRoleProvider#flushRoleCache (not supported))");
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-    @Override
-    public void flushUserCache(String userName) {
-        LOGGER.error("Invoking LightblueLdapRoleProvider#flushUserCache (not supported))");
-        throw new UnsupportedOperationException("Not yet implemented");
-    }
-
-
-
-
 }

--- a/auth/src/main/java/com/redhat/lightblue/rest/authz/RolesCache.java
+++ b/auth/src/main/java/com/redhat/lightblue/rest/authz/RolesCache.java
@@ -34,7 +34,7 @@ public class RolesCache {
                 .removalListener(
                         new RemovalListener<String, List<String>>() {
                             {
-                                LOGGER.info("Removal Listener created");
+                                LOGGER.debug("Removal Listener created");
                             }
 
                             @Override
@@ -52,7 +52,7 @@ public class RolesCache {
                 .removalListener(
                         new RemovalListener<String, List<String>>() {
                             {
-                                LOGGER.info("Removal Listener created");
+                                LOGGER.debug("Removal Listener created");
                             }
 
                             @Override


### PR DESCRIPTION
Initializing InitialLdapContext is expensive (more than 100ms). I think it's safe to create it only once per application startup (won't get stale or anything - it's just a jndi context for ldap).

Other changes:
* cleaned up logging
* removed unused apis