### PR TITLE
Creating InitialLdapContext on every call to ldap

### DIFF
--- a/auth/src/main/java/com/redhat/lightblue/rest/auth/jboss/CertLdapLoginModule.java
+++ b/auth/src/main/java/com/redhat/lightblue/rest/auth/jboss/CertLdapLoginModule.java
@@ -99,9 +99,8 @@ public class CertLdapLoginModule extends BaseCertLoginModule {
 
         Principal p = null;
         try {
-            if (lbLdap == null)
-                // lazy init
-                initializeLightblueLdapRoleProvider();
+
+            initializeLightblueLdapRoleProvider();
 
             LOGGER.debug("Prinicipal username:" + getUsername());
 

--- a/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/InitialLdapContextProvider.java
+++ b/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/InitialLdapContextProvider.java
@@ -1,0 +1,49 @@
+package com.redhat.lightblue.rest.auth.ldap;
+
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.NamingException;
+import javax.naming.ldap.InitialLdapContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Holds configurations needed for ldap lookup and does the lookup on demand.
+ *
+ * @author mpatercz
+ *
+ */
+public class InitialLdapContextProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InitialLdapContextProvider.class);
+
+    private Hashtable<String, Object> env = new Hashtable<>();
+
+    public InitialLdapContextProvider(String server, String bindDn, String bindDNPwd) {
+        LOGGER.debug("init()");
+
+        env.put(Context.SECURITY_AUTHENTICATION, "simple");
+        if (bindDn != null) {
+            env.put(Context.SECURITY_PRINCIPAL, bindDn);
+        }
+        if (bindDNPwd != null) {
+            env.put(Context.SECURITY_CREDENTIALS, bindDNPwd);
+        }
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+        env.put(Context.PROVIDER_URL, server);
+    }
+
+    /**
+     * This call is expensive. InitialLdapContext should be reused, but then we have to deal with
+     * ldap closing the connections. A real pooling with connection validation is needed.
+     *
+     * @throws NamingException
+     */
+    public InitialLdapContext lookupLdap() throws NamingException {
+        LOGGER.debug("createInitialContext()");
+        return new InitialLdapContext(env, null);
+    }
+
+}

--- a/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/LDAPQuery.java
+++ b/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/LDAPQuery.java
@@ -1,7 +1,6 @@
 package com.redhat.lightblue.rest.auth.ldap;
 
 import javax.naming.directory.SearchControls;
-import javax.naming.ldap.LdapContext;
 
 /**
  *
@@ -9,14 +8,12 @@ import javax.naming.ldap.LdapContext;
  */
 public class LDAPQuery {
     final String uid;
-    final LdapContext ldapContext;
     final String ldapSearchBase;
     final String searchFilter;
     final SearchControls searchControls = new SearchControls();
 
-    public LDAPQuery(String uid, LdapContext ldapContext, String ldapSearchBase, String searchFilter, int searchControlScope) {
+    public LDAPQuery(String uid, String ldapSearchBase, String searchFilter, int searchControlScope) {
         this.uid = uid;
-        this.ldapContext = ldapContext;
         this.ldapSearchBase = ldapSearchBase;
         this.searchFilter = searchFilter;
         this.searchControls.setSearchScope(searchControlScope);
@@ -26,7 +23,6 @@ public class LDAPQuery {
     public String toString() {
         return "LDAPCacheKey{" +
                 "uid='" + uid + '\'' +
-                ", ldapContext=" + ldapContext +
                 ", ldapSearchBase='" + ldapSearchBase + '\'' +
                 ", searchFilter='" + searchFilter + '\'' +
                 ", searchControls=" + searchControls +

--- a/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/LDAPSearcher.java
+++ b/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/LDAPSearcher.java
@@ -1,11 +1,11 @@
 package com.redhat.lightblue.rest.auth.ldap;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
 import javax.naming.directory.SearchResult;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class si responsible to handle how to query data from LDAP server and also handle the exceptions different flows
@@ -24,11 +24,11 @@ public class LDAPSearcher {
         return instance;
     }
 
-    public SearchResult searchLDAPServer(LDAPQuery ldapQuery) throws NamingException, LDAPUserNotFoundException, LDAPMultipleUserFoundException {
+    public SearchResult searchLDAPServer(LDAPQuery ldapQuery, InitialLdapContextProvider contextProvider) throws NamingException, LDAPUserNotFoundException, LDAPMultipleUserFoundException {
         LOGGER.debug("LDAPSearcher#searchLDAPServer was invoked and it will call the remote LDAP server");
 
         // Extension a: returns an exception as the LDAP server is down (eg.: this can be meaningful to use the cache )
-        NamingEnumeration<SearchResult> results = ldapQuery.ldapContext.search(ldapQuery.ldapSearchBase, ldapQuery.searchFilter, ldapQuery.searchControls);
+        NamingEnumeration<SearchResult> results = contextProvider.lookupLdap().search(ldapQuery.ldapSearchBase, ldapQuery.searchFilter, ldapQuery.searchControls);
         if (results.hasMoreElements()) {
             SearchResult searchResult = results.nextElement();
 

--- a/auth/src/test/java/com/redhat/lightblue/rest/auth/ldap/LightblueLdapRoleProviderTest.java
+++ b/auth/src/test/java/com/redhat/lightblue/rest/auth/ldap/LightblueLdapRoleProviderTest.java
@@ -119,7 +119,7 @@ public class LightblueLdapRoleProviderTest {
 
         // cache miss
         inOrder.verify(rolesCacheSpy).getIfPresent("derek63");
-        inOrder.verify(ldapSearcherSpy).searchLDAPServer(Mockito.any(LDAPQuery.class));
+        inOrder.verify(ldapSearcherSpy).searchLDAPServer(Mockito.any(LDAPQuery.class), Mockito.any(InitialLdapContextProvider.class));
         inOrder.verify(rolesCacheSpy).put("derek63", expectedUserRoles);
         inOrder.verify(fallbackRolesCacheSpy).put("derek63", expectedUserRoles);
 
@@ -153,7 +153,7 @@ public class LightblueLdapRoleProviderTest {
         Mockito.when(rolesCacheSpy.getIfPresent("derek63")).thenReturn(null);
         // break ldap
         Mockito.doThrow(new RuntimeException(new IOException("connection closed")))
-            .when(ldapSearcherSpy).searchLDAPServer(Mockito.any(LDAPQuery.class));
+            .when(ldapSearcherSpy).searchLDAPServer(Mockito.any(LDAPQuery.class), Mockito.any(InitialLdapContextProvider.class));
 
         // get roles when ldap server is down
         List<String> userRoles = provider.getUserRoles("derek63");


### PR DESCRIPTION
Because it's likely to be responsible for ```Naming problem with LDAP for user: <user>: javax.naming.CommunicationException: connection closed [Root exception is java.io.IOException: connection closed``` errors. Most of the changes are for getting the ldap configs from CertLdapLoginModule down to LDAPSearcher.

Ldap lookup is expensive, but it will be done only when roles are not cached. We could further improve performance by introducing a real ldap connection pool (with validation and restoring stale connections).

