### PR TITLE
Setting up resteasy.providers for lzf

### DIFF
--- a/crud/src/main/webapp/WEB-INF/web.xml
+++ b/crud/src/main/webapp/WEB-INF/web.xml
@@ -36,4 +36,8 @@
         <param-name>cors.configuration.resource</param-name>
         <param-value>lightblue-crud-cors.json</param-value>
     </context-param>
+    <context-param>
+        <param-name>resteasy.providers</param-name>
+        <param-value>com.restcompress.provider.LZFEncodingInterceptor,com.restcompress.provider.LZFDecodingInterceptor</param-value>
+    </context-param>
 </web-app>

--- a/metadata/src/main/webapp/WEB-INF/web.xml
+++ b/metadata/src/main/webapp/WEB-INF/web.xml
@@ -36,4 +36,8 @@
         <param-name>cors.configuration.resource</param-name>
         <param-value>lightblue-metadata-cors.json</param-value>
     </context-param>
+    <context-param>
+        <param-name>resteasy.providers</param-name>
+        <param-value>com.restcompress.provider.LZFEncodingInterceptor,com.restcompress.provider.LZFDecodingInterceptor</param-value>
+    </context-param>
 </web-app>


### PR DESCRIPTION
Resteasy is supposed to scan for classes annotated as providers automatically, however, this does not work even when scanning is enforced with resteasy.scan or resteasy.scan.providers context parameters. Setting providers like this explicitly works.