### PR TITLE
fixes #162 - Remove esb publish hook and limit audit hook to a test dep only

### DIFF
--- a/crud/pom.xml
+++ b/crud/pom.xml
@@ -46,6 +46,7 @@
             <groupId>com.redhat.lightblue.hook</groupId>
             <artifactId>lightblue-audit-hook</artifactId>
             <scope>test</scope>
+            <!-- TODO: Testing the audit hook should be done in the lightblue-rest project -->
         </dependency>
         <dependency>
             <groupId>com.redhat.lightblue</groupId>

--- a/crud/pom.xml
+++ b/crud/pom.xml
@@ -46,7 +46,7 @@
             <groupId>com.redhat.lightblue.hook</groupId>
             <artifactId>lightblue-audit-hook</artifactId>
             <scope>test</scope>
-            <!-- TODO: Testing the audit hook should be done in the lightblue-rest project -->
+            <!-- TODO: Testing the audit hook should not be done in the lightblue-rest project -->
         </dependency>
         <dependency>
             <groupId>com.redhat.lightblue</groupId>

--- a/crud/pom.xml
+++ b/crud/pom.xml
@@ -42,13 +42,10 @@
             <groupId>com.redhat.lightblue</groupId>
             <artifactId>lightblue-core-config</artifactId>
         </dependency>
-        <dependency>
+         <dependency>
             <groupId>com.redhat.lightblue.hook</groupId>
             <artifactId>lightblue-audit-hook</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.redhat.lightblue.hook</groupId>
-            <artifactId>lightblue-esb-hook</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.redhat.lightblue</groupId>

--- a/metadata/pom.xml
+++ b/metadata/pom.xml
@@ -43,14 +43,6 @@
             <artifactId>lightblue-core-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.redhat.lightblue.hook</groupId>
-            <artifactId>lightblue-audit-hook</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.redhat.lightblue.hook</groupId>
-            <artifactId>lightblue-esb-hook</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.redhat.lightblue</groupId>
             <artifactId>lightblue-core-util</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses />.
                 <artifactId>lightblue-audit-hook</artifactId>
                 <version>${lightblue.audithook.version}</version>
                 <scope>test</scope>
-                <!-- TODO: Testing the audit hook should be done in the lightblue-rest project -->
+                <!-- TODO: Testing the audit hook should not be done in the lightblue-rest project -->
             </dependency>
             <dependency>
                 <groupId>com.redhat.lightblue.ldap</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -131,11 +131,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses />.
                 <groupId>com.redhat.lightblue.hook</groupId>
                 <artifactId>lightblue-audit-hook</artifactId>
                 <version>${lightblue.audithook.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.redhat.lightblue.hook</groupId>
-                <artifactId>lightblue-esb-hook</artifactId>
-                <version>${lightblue.esbhook.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.redhat.lightblue.ldap</groupId>
@@ -309,7 +305,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses />.
         <lightblue.mongo.version>1.11.0-SNAPSHOT</lightblue.mongo.version>
         <lightblue.ldap.version>1.8.0-SNAPSHOT</lightblue.ldap.version>
         <lightblue.audithook.version>1.10.0-SNAPSHOT</lightblue.audithook.version>
-        <lightblue.esbhook.version>0.0.6-SNAPSHOT</lightblue.esbhook.version>
     </properties>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses />.
                 <artifactId>lightblue-audit-hook</artifactId>
                 <version>${lightblue.audithook.version}</version>
                 <scope>test</scope>
+                <!-- TODO: Testing the audit hook should be done in the lightblue-rest project -->
             </dependency>
             <dependency>
                 <groupId>com.redhat.lightblue.ldap</groupId>


### PR DESCRIPTION
Associated with https://github.com/lightblue-platform/lightblue-rest/issues/162

Dependencies on https://github.com/lightblue-platform/lightblue-audit-hook/issues/61 and https://github.com/lightblue-platform/lightblue-esb-hook/issues/48