### PR TITLE
remove lightblue-mongo as hard dependency, will now need to be included as a plugin

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -36,10 +36,12 @@
         <dependency>
             <groupId>com.redhat.lightblue.mongo</groupId>
             <artifactId>lightblue-mongo</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.redhat.lightblue.mongo</groupId>
             <artifactId>lightblue-mongo-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.ebaysf.web</groupId>

--- a/crud/pom.xml
+++ b/crud/pom.xml
@@ -61,14 +61,17 @@
         <dependency>
             <groupId>com.redhat.lightblue.mongo</groupId>
             <artifactId>lightblue-mongo</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.redhat.lightblue.mongo</groupId>
             <artifactId>lightblue-mongo-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.redhat.lightblue.rest</groupId>
             <artifactId>lightblue-rest-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/metadata/pom.xml
+++ b/metadata/pom.xml
@@ -61,10 +61,12 @@
         <dependency>
             <groupId>com.redhat.lightblue.mongo</groupId>
             <artifactId>lightblue-mongo</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.redhat.lightblue.mongo</groupId>
             <artifactId>lightblue-mongo-test</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses />.
                 <groupId>com.redhat.lightblue.mongo</groupId>
                 <artifactId>lightblue-mongo</artifactId>
                 <version>${lightblue.mongo.version}</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.redhat.lightblue.mongo</groupId>


### PR DESCRIPTION
This change moves lightblue-mongo into a test scope and will now be required to be deployed independently as a plugin.

Depends on https://github.com/lightblue-platform/lightblue-mongo/pull/211
Associated with https://github.com/lightblue-platform/lightblue-rest/issues/162

I made this a separate PR from https://github.com/lightblue-platform/lightblue-rest/pull/198 in case there were specific concerns around splitting off mongo as it is the only plugin that supports metadata at this point.