### PR TITLE
Revert "remove lightblue-mongo as hard dependency, will now need to be included as a plugin"

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -35,12 +35,10 @@
         <dependency>
             <groupId>com.redhat.lightblue.mongo</groupId>
             <artifactId>lightblue-mongo</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.redhat.lightblue.mongo</groupId>
             <artifactId>lightblue-mongo-test</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.ebaysf.web</groupId>

--- a/crud/pom.xml
+++ b/crud/pom.xml
@@ -57,17 +57,14 @@
         <dependency>
             <groupId>com.redhat.lightblue.mongo</groupId>
             <artifactId>lightblue-mongo</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.redhat.lightblue.mongo</groupId>
             <artifactId>lightblue-mongo-test</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.redhat.lightblue.rest</groupId>
             <artifactId>lightblue-rest-test</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/metadata/pom.xml
+++ b/metadata/pom.xml
@@ -51,12 +51,10 @@
         <dependency>
             <groupId>com.redhat.lightblue.mongo</groupId>
             <artifactId>lightblue-mongo</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.redhat.lightblue.mongo</groupId>
             <artifactId>lightblue-mongo-test</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses />.
                 <groupId>com.redhat.lightblue.mongo</groupId>
                 <artifactId>lightblue-mongo</artifactId>
                 <version>${lightblue.mongo.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>com.redhat.lightblue.mongo</groupId>


### PR DESCRIPTION
Reverts lightblue-platform/lightblue-rest#200

Unexpected casting exception. More research will be needed. Created https://github.com/lightblue-platform/lightblue-mongo/issues/214