### PR TITLE
Fixed npe when no ldap roles are found for user

### DIFF
--- a/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/LightblueLdapRoleProvider.java
+++ b/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/LightblueLdapRoleProvider.java
@@ -57,7 +57,9 @@ public class LightblueLdapRoleProvider implements LightblueRoleProvider {
         try {
 
             List<String> roles = new CachedLdapFindUserRolesByUidCommand(ldapSearchBase, userName, ldapContextProvider).execute();
-            userRoles.addAll(roles);
+            if (roles != null) {
+                userRoles.addAll(roles);
+            }
 
         } catch (HystrixRuntimeException ce) {
             // Not found in cache, returns an empty list


### PR DESCRIPTION
Wanted to add a test, but this is a quirky thing that requires the ldap lookup to fail in a way to return null.  The provider would need some refactoring to make it testable, to allow swapping out the command that's hard coded on line 59.