### PR TITLE
Fixing ldap cache and removing hystrix from ldap cache command class

### DIFF
--- a/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/CachedLdapFindUserRolesByUidCommand.java
+++ b/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/CachedLdapFindUserRolesByUidCommand.java
@@ -14,9 +14,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Strings;
-import com.netflix.hystrix.HystrixCommand;
-import com.netflix.hystrix.HystrixCommandGroupKey;
-import com.netflix.hystrix.HystrixCommandKey;
 import com.redhat.lightblue.hystrix.ServoGraphiteSetup;
 import com.redhat.lightblue.rest.authz.RolesCache;
 
@@ -26,7 +23,8 @@ import com.redhat.lightblue.rest.authz.RolesCache;
  * <p/>
  * Created by nmalik and lcestari and mpatercz
  */
-public class CachedLdapFindUserRolesByUidCommand extends HystrixCommand<List<String>> {
+public class CachedLdapFindUserRolesByUidCommand {
+
     public static final String GROUPKEY = "ldap";
     private static final String INVALID_PARAM = "%s is null or empty";
     private static final Logger LOGGER = LoggerFactory.getLogger(LightblueLdapRoleProvider.class);
@@ -40,8 +38,6 @@ public class CachedLdapFindUserRolesByUidCommand extends HystrixCommand<List<Str
     private final InitialLdapContextProvider ldapContextProvider;
 
     public CachedLdapFindUserRolesByUidCommand(String ldapSearchBase, String uid, InitialLdapContextProvider contextProvider) {
-        super(HystrixCommand.Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey(GROUPKEY)).
-                andCommandKey(HystrixCommandKey.Factory.asKey(GROUPKEY + ":" + CachedLdapFindUserRolesByUidCommand.class.getSimpleName())));
         LOGGER.debug("Creating CachedLdapFindUserRolesByUidCommand");
         //check if the informed parameters are valid
         if (Strings.isNullOrEmpty(uid)) {
@@ -58,8 +54,7 @@ public class CachedLdapFindUserRolesByUidCommand extends HystrixCommand<List<Str
         this.ldapContextProvider = contextProvider;
     }
 
-    @Override
-    protected List<String> run() throws Exception {
+    public List<String> execute() throws Exception {
         LOGGER.debug("CachedLdapFindUserRolesByUidCommand#run was invoked");
 
         List<String> roles = RolesCache.get(ldapQuery.uid);
@@ -82,11 +77,6 @@ public class CachedLdapFindUserRolesByUidCommand extends HystrixCommand<List<Str
             }
 
             return roles;
-
-        } catch (NamingException e) {
-            LOGGER.error("Naming problem with LDAP for user: " + ldapQuery.uid, e);
-            //propagate the exception
-            throw e;
         } catch (LDAPUserNotFoundException | LDAPMultipleUserFoundException e) {
             // Return null in case the User not found or multiple Users were found (which is inconsistent)
 
@@ -97,8 +87,10 @@ public class CachedLdapFindUserRolesByUidCommand extends HystrixCommand<List<Str
             }
 
             return null;
+        } catch (Exception e) {
+            LOGGER.error("Naming problem with LDAP for user: " + ldapQuery.uid, e);
+            return getFallback(ldapQuery);
         }
-
     }
 
     private List<String> getUserRolesFromLdap(SearchResult ldapUser) throws NamingException {
@@ -127,49 +119,18 @@ public class CachedLdapFindUserRolesByUidCommand extends HystrixCommand<List<Str
     }
 
     /**
-     * This methods is executed for all types of failure such as run() failure,
-     * timeout, thread pool or semaphore rejection, and circuit-breaker
-     * short-circuiting.
-     *
+     * This methods is executed for all types of failure such as run() failure.
      */
-    @Override
-    protected List<String> getFallback() {
+    protected List<String> getFallback(LDAPQuery cacheKey) throws CachedLDAPUserNotFoundException {
         LOGGER.warn("Error during the execution of the command. Falling back to the cache");
-        return new FallbackViaLDAPServerProblemCommand(ldapQuery, getFailedExecutionException()).execute();
-    }
-
-    /**
-     * Use the cache in case the LDAP Server was not available and also to we
-     * have metrics around the fallback
-     */
-    private static class FallbackViaLDAPServerProblemCommand extends HystrixCommand<List<String>> {
-        private static final Logger LOGGER = LoggerFactory.getLogger(FallbackViaLDAPServerProblemCommand.class);
-
-        private final LDAPQuery cacheKey;
-        private final Throwable failedExecutionThrowable;
-
-        public FallbackViaLDAPServerProblemCommand(LDAPQuery cacheKey, Throwable failedExecutionThrowable) {
-            super(HystrixCommand.Setter.withGroupKey(HystrixCommandGroupKey.Factory.asKey(GROUPKEY)).
-                    andCommandKey(HystrixCommandKey.Factory.asKey(GROUPKEY + ":" + FallbackViaLDAPServerProblemCommand.class.getSimpleName())));
-            LOGGER.debug("FallbackViaLDAPServerProblemCommand constructor");
-            this.cacheKey = cacheKey;
-            this.failedExecutionThrowable = failedExecutionThrowable;
+        List<String> roles = RolesCache.getFromFallback(cacheKey.uid);
+        if (roles == null) {
+            CachedLDAPUserNotFoundException e = new CachedLDAPUserNotFoundException();
+            LOGGER.error("Failed to connect to the server and no result found roles for user: " + cacheKey.uid, e);
+            throw e;
         }
-
-        @Override
-        protected List<String> run() throws Exception {
-            LOGGER.debug("FallbackViaLDAPServerProblemCommand#run was invoked and the following Exception caused the fallback", failedExecutionThrowable);
-            List<String> roles = RolesCache.getFromFallback(cacheKey.uid);
-            if (roles == null) {
-                CachedLDAPUserNotFoundException e = new CachedLDAPUserNotFoundException();
-                LOGGER.error("Failed to connect to the server and no result found roles for user: " + cacheKey.uid, e);
-                throw e;
-            }
-            // was able to use the cache or use the LDAP server on the second retry
-            LOGGER.debug("FallbackViaLDAPServerProblemCommand#run : user found!");
-            return roles;
-        }
-
+        // was able to use the cache or use the LDAP server on the second retry
+        LOGGER.debug("FallbackViaLDAPServerProblemCommand#run : user found!");
+        return roles;
     }
-
 }

--- a/auth/src/main/java/com/redhat/lightblue/rest/authz/RolesCache.java
+++ b/auth/src/main/java/com/redhat/lightblue/rest/authz/RolesCache.java
@@ -48,19 +48,7 @@ public class RolesCache {
         fallbackRolesCache = CacheBuilder.newBuilder()
                 .concurrencyLevel(10) // handle 10 concurrent request without a problem
                 .maximumSize(500) // Hold 500 sessions before remove them
-                .expireAfterWrite(5, TimeUnit.HOURS) // If the session is inactive for more than 5 hours, remove it
-                .removalListener(
-                        new RemovalListener<String, List<String>>() {
-                            {
-                                LOGGER.debug("Removal Listener created");
-                            }
-
-                            @Override
-                            public void onRemoval(@ParametersAreNonnullByDefault RemovalNotification notification) {
-                                LOGGER.debug("This data from " + notification.getKey() + " evacuated due:" + notification.getCause());
-                            }
-                        }
-                ).build();
+                .build();
         LOGGER.debug("RolesCache: fallbackRolesCache was created on a static block");
     }
 


### PR DESCRIPTION
In prod we see intermittent issues getting roles from ldap that result in requests failing for clients.  It's not frequent, but only thing I can see as a problem is we expire records in the fallback cache for ldap roles.  So, this change removes that expiration.  In addition, I ripped hystrix out of that command class to simplify things and make it easier to follow.  We wanted to remove hystrix anyway, so this is a start.