### PR TITLE
Release script

### DIFF
--- a/etc/release.sh
+++ b/etc/release.sh
@@ -36,7 +36,7 @@ if [ $MERGE_BASE != $HEAD_HASH ]; then
 fi
 
 # update to non-snapshot versions of lightblue dependencies and commit
-mvn versions:update-properties -DallowSnapshots=false
+mvn versions:update-properties -Dincludes=*lightblue* -DallowSnapshots=false
 git commit -a -m "Updated versions to non snapshot"
 
 # prepare for release (note, this will warn if any snapshot dependencies still exist and allow for fixing)

--- a/lightblue-rest-integration-test/pom.xml
+++ b/lightblue-rest-integration-test/pom.xml
@@ -10,6 +10,11 @@
   <artifactId>lightblue-rest-integration-test</artifactId>
   <name>lightblue-rest: ${project.groupId}|${project.artifactId}</name>
   
+  <properties>
+    <org.jboss.resteasy.version>3.0.19.Final</org.jboss.resteasy.version>
+    <io.undertow.version>1.3.25.Final</io.undertow.version>
+  </properties>
+  
   <dependencies>
     <dependency>
         <groupId>com.redhat.lightblue</groupId>
@@ -42,17 +47,17 @@
     <dependency>
         <groupId>io.undertow</groupId>
         <artifactId>undertow-servlet</artifactId>
-        <version>1.3.25.Final</version>
+        <version>${io.undertow.version}</version>
     </dependency>
     <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-undertow</artifactId>
-        <version>3.0.19.Final</version>
+        <version>${org.jboss.resteasy.version}</version>
     </dependency>
     <dependency>
         <groupId>org.jboss.resteasy</groupId>
         <artifactId>resteasy-jaxrs</artifactId>
-        <version>3.0.19.Final</version>
+        <version>${org.jboss.resteasy.version}</version>
     </dependency>
     
     <dependency>


### PR DESCRIPTION
Ran into an issue during the last release where non-lightblue related property versions were updated. Changing release script to only update lightblue dependencies