### PR TITLE
Turn LdapRepository into a singleton to maintain a single ldap connection pool

### DIFF
--- a/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/LightblueLdapRoleProvider.java
+++ b/auth/src/main/java/com/redhat/lightblue/rest/auth/ldap/LightblueLdapRoleProvider.java
@@ -50,7 +50,7 @@ public class LightblueLdapRoleProvider implements LightblueRoleProvider {
                 .bindDNPwd(bindDNPwd)
                 .poolSize(1)
                 .useSSL(false);
-        ldapRepository = new LdapRepository(ldapConfiguration);
+        ldapRepository = LdapRepository.getInstance(ldapConfiguration);
     }
 
     public LightblueLdapRoleProvider(String server, String port, String searchBase, String bindDn, String bindDNPwd,
@@ -67,7 +67,7 @@ public class LightblueLdapRoleProvider implements LightblueRoleProvider {
                 .trustStore(trustStore)
                 .trustStorePassword(trustStorePassword)
                 .poolSize(Integer.parseInt(poolSize));
-        ldapRepository = new LdapRepository(ldapConfiguration);
+        ldapRepository = LdapRepository.getInstance(ldapConfiguration);
     }
 
     @Override

--- a/auth/src/test/java/com/redhat/lightblue/rest/auth/ldap/LightblueLdapRoleProviderTest.java
+++ b/auth/src/test/java/com/redhat/lightblue/rest/auth/ldap/LightblueLdapRoleProviderTest.java
@@ -154,6 +154,8 @@ public class LightblueLdapRoleProviderTest {
         // expire cache
         when(rolesCacheSpy.getIfPresent("derek63")).thenReturn(null);
 
+        // force connection pool init to make ldap fail
+        LdapRepository.connectionPool = null;
         // get roles when ldap server is down
         List<String> userRoles = downProvider.getUserRoles("derek63");
 


### PR DESCRIPTION
This is a follow up to https://github.com/lightblue-platform/lightblue-rest/pull/260.

@derek63, the connection pool is initialized each time LdapRepository.initialize() is called, which is every time results are not found in cache. With your fix applied, I think we will end up having as many pools as we have different users calling within roles cache expiry threshold. We need to ensure we have only one pool at all times or not use a pool at all.

Here is my quick fix. I don't like it very much, because it makes it impossible to create multiple LdapRepository instances with different LdapConfigurations. We don't need to do that right now, so I guess that's fine.