### PR TITLE
added the missing comma

### DIFF
--- a/etc/jbossas/modules/com/redhat/lightblue/main/datasources.json
+++ b/etc/jbossas/modules/com/redhat/lightblue/main/datasources.json
@@ -16,7 +16,7 @@
            "host" : "localhost",
            "port" : "27017"
         }
-   }
+   },
    "mongodata" : {
      "documentation" : [
        "MongoDB makes a distinction between servers (a list) and server (a single address), ",


### PR DESCRIPTION
Caused by: com.fasterxml.jackson.core.JsonParseException: Unexpected character ('"' (code 34)): was expecting comma to separate OBJECT entries