### PR TITLE
Revert "Skipped LDAP healthcheck due to roles provider not available during context initialization"

### DIFF
--- a/crud-cert-auth/src/main/java/com/redhat/lightblue/rest/crud/cert/auth/health/CrudCertAuthHealthCheckServletContextListener.java
+++ b/crud-cert-auth/src/main/java/com/redhat/lightblue/rest/crud/cert/auth/health/CrudCertAuthHealthCheckServletContextListener.java
@@ -39,11 +39,9 @@ public class CrudCertAuthHealthCheckServletContextListener extends HealthCheckSe
             }
         }
         
-        if (CertLdapLoginModule.getRolesProvider() != null) {
-            healthCheckRegistry.register("ldap-auth-healthcheck",
-                    new RolesProviderHealthCheck(CertLdapLoginModule.getRolesProvider()));
-        }
-        
+        healthCheckRegistry.register("ldap-auth-healthcheck",
+                new RolesProviderHealthCheck(CertLdapLoginModule.getRolesProvider()));
+
         return healthCheckRegistry;
     }
 }


### PR DESCRIPTION
Reverts lightblue-platform/lightblue-rest#291