### PR TITLE
fix flapdoodle issues

### DIFF
--- a/crud/src/test/java/com/redhat/lightblue/rest/crud/ITCaseCrudResourceTest.java
+++ b/crud/src/test/java/com/redhat/lightblue/rest/crud/ITCaseCrudResourceTest.java
@@ -18,6 +18,9 @@
  */
 package com.redhat.lightblue.rest.crud;
 
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.mongodb.BasicDBObject;
@@ -34,19 +37,36 @@ import com.redhat.lightblue.rest.test.support.Assets;
 import com.redhat.lightblue.rest.test.support.CrudWebXmls;
 import com.redhat.lightblue.util.JsonUtils;
 import com.redhat.lightblue.util.test.FileUtil;
-import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
 import de.flapdoodle.embed.mongo.MongodStarter;
 import de.flapdoodle.embed.mongo.config.Defaults;
 import de.flapdoodle.embed.mongo.config.MongodConfig;
 import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.mongo.packageresolver.Command;
 import de.flapdoodle.embed.process.config.RuntimeConfig;
-import de.flapdoodle.embed.process.config.io.ProcessOutput;
 import de.flapdoodle.embed.process.config.store.TimeoutConfig;
-import de.flapdoodle.embed.process.io.Processors;
+import de.flapdoodle.embed.process.extract.DirectoryAndExecutableNaming;
+import de.flapdoodle.embed.process.extract.UserTempNaming;
 import de.flapdoodle.embed.process.io.StreamProcessor;
+import de.flapdoodle.embed.process.io.directories.PlatformTempDir;
 import de.flapdoodle.embed.process.runtime.Network;
+import de.flapdoodle.embed.process.store.Downloader;
+import de.flapdoodle.embed.process.store.ExtractedArtifactStore;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import javax.inject.Inject;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriBuilder;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -65,421 +85,445 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
-
-import javax.inject.Inject;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.UriBuilder;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Duration;
-
-import static org.junit.Assert.assertTrue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- *
  * @author lcestari
  */
 @RunWith(Arquillian.class)
 public class ITCaseCrudResourceTest {
 
-    @Rule
-    public final RestConfigurationRule resetRuleConfiguration = new RestConfigurationRule();
+  private static final Logger LOGGER = LoggerFactory.getLogger("ITCaseCrudResourceTest");
+  @Rule
+  public final RestConfigurationRule resetRuleConfiguration = new RestConfigurationRule();
 
-    public static class FileStreamProcessor implements StreamProcessor {
-        private final FileOutputStream outputStream;
+  public static class FileStreamProcessor implements StreamProcessor {
 
-        public FileStreamProcessor(File file) throws FileNotFoundException {
-            outputStream = new FileOutputStream(file);
-        }
+    private final FileOutputStream outputStream;
 
+    public FileStreamProcessor(File file) throws FileNotFoundException {
+      outputStream = new FileOutputStream(file);
+    }
+
+    @Override
+    public void process(String block) {
+      try {
+        outputStream.write(block.getBytes());
+      } catch (IOException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+
+    @Override
+    public void onProcessed() {
+      try {
+        outputStream.close();
+      } catch (IOException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+
+  }
+
+  private static final String MONGO_HOST = "localhost";
+  private static final int MONGO_PORT = 27757;
+  private static final String IN_MEM_CONNECTION_URL = MONGO_HOST + ":" + MONGO_PORT;
+
+  private static final String DB_NAME = "mongo";
+
+  private static MongodExecutable mongodExe;
+  private static MongodProcess mongod;
+  private static MongoClient mongo;
+  private static DB db;
+
+  static {
+    try {
+
+      RuntimeConfig runtimeConfig = Defaults.runtimeConfigFor(Command.MongoD)
+          .artifactStore(ExtractedArtifactStore.builder()
+              .extraction(DirectoryAndExecutableNaming.builder()
+                  .executableNaming(new UserTempNaming())
+                  .directory(new PlatformTempDir()).build())
+              .downloader(Downloader.platformDefault())
+              .temp(DirectoryAndExecutableNaming.builder()
+                  .executableNaming(new UserTempNaming())
+                  .directory(new PlatformTempDir()).build())
+              .downloadConfig(Defaults.downloadConfigFor(Command.MongoD)
+                  .timeoutConfig(TimeoutConfig.builder()
+                      .connectionTimeout((int) Duration.ofMinutes(1).toMillis())
+                      .readTimeout((int) Duration.ofMinutes(5).toMillis())
+                      .build())
+                  .fileNaming(new UserTempNaming()).build())
+              .build())
+          .build();
+
+      MongodStarter runtime = MongodStarter.getInstance(runtimeConfig);
+      mongodExe = runtime.prepare(
+          MongodConfig.builder()
+              .version(Version.V5_0_2)
+              .net(new Net(MONGO_PORT, Network.localhostIsIPv6()))
+              .build()
+      );
+      try {
+        mongod = mongodExe.start();
+      } catch (Throwable t) {
+        // try again, could be killed breakpoint in IDE
+        mongod = mongodExe.start();
+      }
+      mongo = new MongoClient(IN_MEM_CONNECTION_URL);
+
+      MongoConfiguration config = new MongoConfiguration();
+      // disable ssl for test (enabled by default)
+      config.setDatabase(DB_NAME);
+      config.setSsl(Boolean.FALSE);
+      config.addServerAddress(MONGO_HOST, MONGO_PORT);
+
+      db = config.getDB();
+
+      Runtime.getRuntime().addShutdownHook(new Thread() {
         @Override
-        public void process(String block) {
-            try {
-                outputStream.write(block.getBytes());
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
+        public void run() {
+          super.run();
+          clearDatabase();
         }
 
-        @Override
-        public void onProcessed() {
-            try {
-                outputStream.close();
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
-        }
+      });
+    } catch (IOException e) {
+      throw new java.lang.Error(e);
+    }
+  }
 
+  @Before
+  public void setup() {
+    db.createCollection(MongoMetadata.DEFAULT_METADATA_COLLECTION, null);
+    db.createCollection("audit", null);
+    BasicDBObject index = new BasicDBObject("name", 1);
+    index.put("version.value", 1);
+    db.getCollection(MongoMetadata.DEFAULT_METADATA_COLLECTION).createIndex(index, "name", true);
+  }
+
+  @After
+  public void teardown() {
+    if (mongo != null) {
+      mongo.dropDatabase(DB_NAME);
+    }
+  }
+
+  public static void clearDatabase() {
+    if (mongod != null) {
+      mongod.stop();
+      mongodExe.stop();
+    }
+    db = null;
+    mongo = null;
+    mongod = null;
+    mongodExe = null;
+  }
+
+  @Deployment
+  public static WebArchive createDeployment() throws Exception {
+    File[] libs = Maven.resolver()
+        .loadPomFromFile("pom.xml")
+        .importRuntimeDependencies()
+        .resolve()
+        .withTransitivity()
+        .asFile();
+
+    Path configBase = Paths.get("src/test/resources/",
+        ITCaseCrudResourceTest.class.getSimpleName(),
+        "/config/");
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "lightblue.war")
+        .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+        .addAsWebInfResource(
+            Assets.forDocument(CrudWebXmls.forNonEE6Container(RestApplication.class)), "web.xml")
+        .addAsLibraries(Maven.configureResolver()
+            .workOffline()
+            .loadPomFromFile("pom.xml")
+            .resolve("org.jboss.weld.servlet:weld-servlet")
+            .withTransitivity()
+            .asFile())
+        .addPackages(true, "com.redhat.lightblue")
+        .addAsResource(configBase.resolve(MetadataConfiguration.FILENAME).toFile())
+        .addAsResource(configBase.resolve(CrudConfiguration.FILENAME).toFile())
+        .addAsResource(configBase.resolve(RestConfiguration.DATASOURCE_FILENAME).toFile())
+        .addAsResource(configBase.resolve("config.properties").toFile());
+
+    for (File file : libs) {
+      if (!file.toString().contains("lightblue-")) {
+        archive.addAsLibrary(file);
+      }
     }
 
-    private static final String MONGO_HOST = "localhost";
-    private static final int MONGO_PORT = 27757;
-    private static final String IN_MEM_CONNECTION_URL = MONGO_HOST + ":" + MONGO_PORT;
+    return archive;
+  }
 
-    private static final String DB_NAME = "mongo";
+  private String readFile(String filename) throws IOException, URISyntaxException {
+    return FileUtil.readFile(this.getClass().getSimpleName() + "/" + filename);
+  }
 
-    private static MongodExecutable mongodExe;
-    private static MongodProcess mongod;
-    private static MongoClient mongo;
-    private static DB db;
+  @Inject
+  private CrudResource cutCrudResource; //class under test
 
-    static {
-        try {
-            StreamProcessor mongodOutput = Processors.named("[mongod>]",
-                    new FileStreamProcessor(File.createTempFile("mongod", "log")));
-            StreamProcessor mongodError = new FileStreamProcessor(File.createTempFile("mongod-error", "log"));
-            StreamProcessor commandsOutput = Processors.namedConsole("[console>]");
+  @Test
+  public void testFirstIntegrationTest()
+      throws IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException, URISyntaxException, JSONException {
+    Assert.assertNotNull("CrudResource was not injected by the container", cutCrudResource);
 
-            Command mongoD = Command.MongoD;
-            RuntimeConfig runtimeConfig = Defaults.runtimeConfigFor(mongoD)
-                .processOutput(new ProcessOutput(mongodOutput, mongodError, commandsOutput))
-                .artifactStore(Defaults.extractedArtifactStoreFor(mongoD)
-                    .withDownloadConfig(Defaults.downloadConfigFor(mongoD)
-                        .timeoutConfig(TimeoutConfig.builder()
-                            .connectionTimeout((int) Duration.ofMinutes(1).toMillis())
-                            .readTimeout((int) Duration.ofMinutes(5).toMillis())
-                            .build()).build()))
-                .build();
+    String auditExpectedCreated = readFile("auditExpectedCreated.json");
+    String auditMetadata = FileUtil.readFile("metadata/audit.json");
+    EntityMetadata aEm = RestConfiguration.getFactory().getJSONParser()
+        .parseEntityMetadata(JsonUtils.json(auditMetadata));
+    RestConfiguration.getFactory().getMetadata().createNewMetadata(aEm);
+    EntityMetadata aEm2 = RestConfiguration.getFactory().getMetadata()
+        .getEntityMetadata("audit", "1.0.1");
+    String auditResultCreated = RestConfiguration.getFactory().getJSONParser().convert(aEm2)
+        .toString();
+    JSONAssert.assertEquals(auditExpectedCreated, auditResultCreated, false);
 
-            MongodStarter runtime = MongodStarter.getInstance(runtimeConfig);
-            mongodExe = runtime.prepare(
-                    MongodConfig.builder()
-                    .version(de.flapdoodle.embed.mongo.distribution.Version.V3_1_6)
-                    .net(new Net(MONGO_PORT, Network.localhostIsIPv6()))
-                    .build()
-            );
-            try {
-                mongod = mongodExe.start();
-            } catch (Throwable t) {
-                // try again, could be killed breakpoint in IDE
-                mongod = mongodExe.start();
-            }
-            MongoClient mongoClient = new MongoClient(IN_MEM_CONNECTION_URL);
-            mongo = mongoClient;
+    String expectedCreated = readFile("expectedCreated.json");
+    String metadata = readFile("metadata.json");
+    EntityMetadata em = RestConfiguration.getFactory().getJSONParser()
+        .parseEntityMetadata(JsonUtils.json(metadata));
+    RestConfiguration.getFactory().getMetadata().createNewMetadata(em);
+    EntityMetadata em2 = RestConfiguration.getFactory().getMetadata()
+        .getEntityMetadata("country", "1.0.0");
+    String resultCreated = RestConfiguration.getFactory().getJSONParser().convert(em2).toString();
+    JSONAssert.assertEquals(expectedCreated, resultCreated, false);
 
-            MongoConfiguration config = new MongoConfiguration();
-            // disable ssl for test (enabled by default)
-            config.setDatabase(DB_NAME);
-            config.setSsl(Boolean.FALSE);
-            config.addServerAddress(MONGO_HOST, MONGO_PORT);
+    String expectedInserted = readFile("expectedInserted.json");
+    String resultInserted = cutCrudResource.insert("country", "1.0.0",
+        readFile("resultInserted.json")).getEntity().toString();
+    JSONAssert.assertEquals(expectedInserted, resultInserted, false);
 
-            db = config.getDB();
+    String auditExpectedFound = readFile("auditExpectedFound.json");
+    String auditResultFound = cutCrudResource.find("audit", "1.0.1", false,
+        readFile("auditResultFound.json")).getEntity().toString();
+    LOGGER.debug("resultFound:" + auditResultFound);
+    auditResultFound = auditResultFound.replaceAll("\"_id\":\".*?\"", "\"_id\":\"\"");
+    auditResultFound = auditResultFound.replaceAll(
+        "\"lastUpdateDate\":\"\\d{8}T\\d\\d:\\d\\d:\\d\\d\\.\\d{3}[+-]\\d{4}\"",
+        "\"lastUpdateDate\":\"\"");
+    JSONAssert.assertEquals(auditExpectedFound, auditResultFound, false);
 
-            Runtime.getRuntime().addShutdownHook(new Thread() {
-                @Override
-                public void run() {
-                    super.run();
-                    clearDatabase();
-                }
+    String bulkResult = cutCrudResource.bulk(readFile("bulkReq.json")).getEntity().toString();
+    bulkResult = bulkResult.replaceAll("\"_id\":\".*?\"", "\"_id\":\"\"");
+    bulkResult = bulkResult.replaceAll(
+        "\"lastUpdateDate\":\"\\d{8}T\\d\\d:\\d\\d:\\d\\d\\.\\d{3}[+-]\\d{4}\"",
+        "\"lastUpdateDate\":\"\"");
+    JSONAssert.assertEquals(readFile("bulkResult.json"), bulkResult, false);
 
-            });
-        } catch (IOException e) {
-            throw new java.lang.Error(e);
-        }
-    }
+    String expectedUpdated = readFile("expectedUpdated.json");
+    String resultUpdated = cutCrudResource.update("country", "1.0.0",
+        readFile("resultUpdated.json")).getEntity().toString();
+    JSONAssert.assertEquals(expectedUpdated, resultUpdated, false);
 
-    @Before
-    public void setup() throws Exception {
-        db.createCollection(MongoMetadata.DEFAULT_METADATA_COLLECTION, null);
-        db.createCollection("audit", null);
-        BasicDBObject index = new BasicDBObject("name", 1);
-        index.put("version.value", 1);
-        db.getCollection(MongoMetadata.DEFAULT_METADATA_COLLECTION).createIndex(index, "name", true);
-    }
+    // TODO: once https://github.com/lightblue-platform/lightblue-core/issues/476 is fixed, restore
+    // audit# fields in auditExpectedFound.json
+    // String audit2ExpectedFound = readFile("auditExpectedFoundUpdate.json");
+    // String audit2ResultFound = cutCrudResource.find("audit", "1.0.1", readFile("auditResultFound.json")).getEntity().toString();
+    // audit2ResultFound = audit2ResultFound.replaceAll("\"_id\":\".*?\"", "\"_id\":\"\"");
+    // audit2ResultFound = audit2ResultFound.replaceAll("\"lastUpdateDate\":\"\\d{8}T\\d\\d:\\d\\d:\\d\\d\\.\\d{3}[+-]\\d{4}\"", "\"lastUpdateDate\":\"\"");
+    // JSONAssert.assertEquals(audit2ExpectedFound, audit2ResultFound, false);
+    String expectedFound = readFile("expectedFound.json");
+    String resultFound = cutCrudResource.find("country", "1.0.0", false,
+        readFile("resultFound.json")).getEntity().toString();
+    JSONAssert.assertEquals(expectedFound, resultFound,
+        false); // #TODO #FIX Not finding the right version
 
-    @After
-    public void teardown() {
-        if (mongo != null) {
-            mongo.dropDatabase(DB_NAME);
-        }
-    }
+    String expectedAll = cutCrudResource.find("country", "1.0.0", false,
+        readFile("country-noq.json")).getEntity().toString();
+    LOGGER.debug("returnVAlue:" + expectedAll);
+    JSONAssert.assertEquals(expectedFound, expectedAll, false);
 
-    public static void clearDatabase() {
-        if (mongod != null) {
-            mongod.stop();
-            mongodExe.stop();
-        }
-        db = null;
-        mongo = null;
-        mongod = null;
-        mongodExe = null;
-    }
+    String resultSimpleFound = cutCrudResource.simpleFind( //?Q&P&S&from&to
+        "country",
+        "1.0.0",
+        "iso2code:CA,QE;iso2code:CA;iso2code:CA,EN",
+        "name:1r,iso3code:1,iso2code:0r",
+        "name:a,iso3code:d,iso2code:d",
+        0L,
+        100L, null).getEntity().toString();
+    JSONAssert.assertEquals(expectedFound, resultSimpleFound, false);
 
-    @Deployment
-    public static WebArchive createDeployment() throws Exception {
-        File[] libs = Maven.resolver()
-                .loadPomFromFile("pom.xml")
-                .importRuntimeDependencies()
-                .resolve()
-                .withTransitivity()
-                .asFile();
+    resultSimpleFound = cutCrudResource.simpleFind( //?Q&P&S&from&to
+        "country",
+        "1.0.0",
+        "iso2code:CA,QE;iso2code:CA;iso2code:CA,EN",
+        "name:1r,iso3code:1,iso2code:0r",
+        "name:a,iso3code:d,iso2code:d",
+        0L,
+        null, 1L).getEntity().toString();
+    JSONAssert.assertEquals(expectedFound, resultSimpleFound, false);
 
-        Path configBase = Paths.get("src/test/resources/",
-                ITCaseCrudResourceTest.class.getSimpleName(),
-                "/config/");
+    String resultSimpleFromToNotSetFound = cutCrudResource.simpleFind( //?Q&P&S&from&to
+        "country",
+        "1.0.0",
+        "iso2code:CA,QE;iso2code:CA;iso2code:CA,EN",
+        "name:1r,iso3code:1,iso2code:0r",
+        "name:a,iso3code:d,iso2code:d",
+        null,
+        null, null).getEntity().toString();
+    JSONAssert.assertEquals(expectedFound, resultSimpleFromToNotSetFound, false);
 
-        WebArchive archive = ShrinkWrap.create(WebArchive.class, "lightblue.war")
-            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-            .addAsWebInfResource(Assets.forDocument(CrudWebXmls.forNonEE6Container(RestApplication.class)), "web.xml")
-            .addAsLibraries(Maven.configureResolver()
-                    .workOffline()
-                    .loadPomFromFile("pom.xml")
-                    .resolve("org.jboss.weld.servlet:weld-servlet")
-                    .withTransitivity()
-                    .asFile())
-            .addPackages(true, "com.redhat.lightblue")
-            .addAsResource(configBase.resolve(MetadataConfiguration.FILENAME).toFile())
-            .addAsResource(configBase.resolve(CrudConfiguration.FILENAME).toFile())
-            .addAsResource(configBase.resolve(RestConfiguration.DATASOURCE_FILENAME).toFile())
-            .addAsResource(configBase.resolve("config.properties").toFile());
+    String expectedDeleted = readFile("expectedDeleted.json");
+    String resultDeleted = cutCrudResource.delete("country", "1.0.0",
+        readFile("resultDeleted.json")).getEntity().toString();
+    JSONAssert.assertEquals(expectedDeleted, resultDeleted, false);
 
-        for (File file : libs) {
-            if (!file.toString().contains("lightblue-")) {
-                archive.addAsLibrary(file);
-            }
-        }
+    String expectedFound2 = readFile("expectedFound2.json");
+    String resultFound2 = cutCrudResource.find("country", "1.0.0", false,
+        readFile("resultFound2.json")).getEntity().toString();
+    JSONAssert.assertEquals(expectedFound2, resultFound2, false);
+  }
 
-        return archive;
-    }
+  @Test
+  public void testLock() {
+    Assert.assertNotNull("CrudResource was not injected by the container", cutCrudResource);
+    String result = cutCrudResource.acquire("test", "caller", "resource", null).getEntity()
+        .toString();
+    Assert.assertEquals("{\"result\":true}", result);
+  }
 
-    private String readFile(String filename) throws IOException, URISyntaxException {
-        return FileUtil.readFile(this.getClass().getSimpleName() + "/" + filename);
-    }
+  @Test
+  public void testLockWithPost() {
+    Assert.assertNotNull("CrudResource was not injected by the container", cutCrudResource);
 
-    @Inject
-    private CrudResource cutCrudResource; //class under test
+    String request =
+        "{" +
+            "\"operation\" : \"acquire\"," +
+            "\"domain\" : \"test\"," +
+            "\"callerId\" : \"caller\"," +
+            "\"resourceId\" : \"resource/slash\"" +
+            "}";
 
-    @Test
-    public void testFirstIntegrationTest() throws IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException, URISyntaxException, JSONException {
-        Assert.assertNotNull("CrudResource was not injected by the container", cutCrudResource);
+    String result = cutCrudResource.lock(request).getEntity().toString();
+    Assert.assertEquals("{\"result\":true}", result);
+  }
 
-        String auditExpectedCreated = readFile("auditExpectedCreated.json");
-        String auditMetadata = FileUtil.readFile("metadata/audit.json");
-        EntityMetadata aEm = RestConfiguration.getFactory().getJSONParser().parseEntityMetadata(JsonUtils.json(auditMetadata));
-        RestConfiguration.getFactory().getMetadata().createNewMetadata(aEm);
-        EntityMetadata aEm2 = RestConfiguration.getFactory().getMetadata().getEntityMetadata("audit", "1.0.1");
-        String auditResultCreated = RestConfiguration.getFactory().getJSONParser().convert(aEm2).toString();
-        JSONAssert.assertEquals(auditExpectedCreated, auditResultCreated, false);
+  @Test
+  public void testGenerate()
+      throws IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException, URISyntaxException, JSONException {
+    Assert.assertNotNull("CrudResource was not injected by the container", cutCrudResource);
+    String metadata = readFile("generator-md.json");
+    EntityMetadata em = RestConfiguration.getFactory().getJSONParser()
+        .parseEntityMetadata(JsonUtils.json(metadata));
+    RestConfiguration.getFactory().getMetadata().createNewMetadata(em);
 
-        String expectedCreated = readFile("expectedCreated.json");
-        String metadata = readFile("metadata.json");
-        EntityMetadata em = RestConfiguration.getFactory().getJSONParser().parseEntityMetadata(JsonUtils.json(metadata));
-        RestConfiguration.getFactory().getMetadata().createNewMetadata(em);
-        EntityMetadata em2 = RestConfiguration.getFactory().getMetadata().getEntityMetadata("country", "1.0.0");
-        String resultCreated = RestConfiguration.getFactory().getJSONParser().convert(em2).toString();
-        JSONAssert.assertEquals(expectedCreated, resultCreated, false);
+    String result = cutCrudResource.generate("generate", "1.0.0", "number", 1).getEntity()
+        .toString();
+    LOGGER.debug("Generated:" + result);
+    JSONAssert.assertEquals("{\"processed\":[\"50000000\"]}", result, false);
 
-        String expectedInserted = readFile("expectedInserted.json");
-        String resultInserted = cutCrudResource.insert("country", "1.0.0", readFile("resultInserted.json")).getEntity().toString();
-        JSONAssert.assertEquals(expectedInserted, resultInserted, false);
+    result = cutCrudResource.generate("generate", "number", 3).getEntity().toString();
+    LOGGER.debug("Generated:" + result);
+    JSONAssert.assertEquals("{\"processed\":[\"50000001\",\"50000002\",\"50000003\"]}", result,
+        false);
+  }
 
-        String auditExpectedFound = readFile("auditExpectedFound.json");
-        String auditResultFound = cutCrudResource.find("audit", "1.0.1", false,readFile("auditResultFound.json")).getEntity().toString();
-        System.out.println("resultFound:" + auditResultFound);
-        auditResultFound = auditResultFound.replaceAll("\"_id\":\".*?\"", "\"_id\":\"\"");
-        auditResultFound = auditResultFound.replaceAll("\"lastUpdateDate\":\"\\d{8}T\\d\\d:\\d\\d:\\d\\d\\.\\d{3}[+-]\\d{4}\"", "\"lastUpdateDate\":\"\"");
-        JSONAssert.assertEquals(auditExpectedFound, auditResultFound, false);
+  @Test
+  public void testSavedSearch()
+      throws IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException, URISyntaxException {
+    Assert.assertNotNull("CrudResource was not injected by the container", cutCrudResource);
 
-        String bulkResult = cutCrudResource.bulk(readFile("bulkReq.json")).getEntity().toString();
-        bulkResult = bulkResult.replaceAll("\"_id\":\".*?\"", "\"_id\":\"\"");
-        bulkResult = bulkResult.replaceAll("\"lastUpdateDate\":\"\\d{8}T\\d\\d:\\d\\d:\\d\\d\\.\\d{3}[+-]\\d{4}\"", "\"lastUpdateDate\":\"\"");
-        JSONAssert.assertEquals(readFile("bulkResult.json"), bulkResult, false);
+    // Saved search metadata
+    LOGGER.debug("Insert saved search md");
+    String metadata = readFile("lb-saved-search.json");
+    EntityMetadata em = RestConfiguration.getFactory().getJSONParser()
+        .parseEntityMetadata(JsonUtils.json(metadata));
+    RestConfiguration.getFactory().getMetadata().createNewMetadata(em);
+    LOGGER.debug("saved search md inserted");
 
-        String expectedUpdated = readFile("expectedUpdated.json");
-        String resultUpdated = cutCrudResource.update("country", "1.0.0", readFile("resultUpdated.json")).getEntity().toString();
-        JSONAssert.assertEquals(expectedUpdated, resultUpdated, false);
+    // Country metadata
+    LOGGER.debug("Insert country md");
+    metadata = readFile("metadata.json");
+    em = RestConfiguration.getFactory().getJSONParser()
+        .parseEntityMetadata(JsonUtils.json(metadata));
+    RestConfiguration.getFactory().getMetadata().createNewMetadata(em);
+    LOGGER.debug("country md inserted");
+    String auditMetadata = FileUtil.readFile("metadata/audit.json");
+    EntityMetadata aEm = RestConfiguration.getFactory().getJSONParser()
+        .parseEntityMetadata(JsonUtils.json(auditMetadata));
+    RestConfiguration.getFactory().getMetadata().createNewMetadata(aEm);
 
-        // TODO: once https://github.com/lightblue-platform/lightblue-core/issues/476 is fixed, restore
-        // audit# fields in auditExpectedFound.json
-        // String audit2ExpectedFound = readFile("auditExpectedFoundUpdate.json");
-        // String audit2ResultFound = cutCrudResource.find("audit", "1.0.1", readFile("auditResultFound.json")).getEntity().toString();
-        // audit2ResultFound = audit2ResultFound.replaceAll("\"_id\":\".*?\"", "\"_id\":\"\"");
-        // audit2ResultFound = audit2ResultFound.replaceAll("\"lastUpdateDate\":\"\\d{8}T\\d\\d:\\d\\d:\\d\\d\\.\\d{3}[+-]\\d{4}\"", "\"lastUpdateDate\":\"\"");
-        // JSONAssert.assertEquals(audit2ExpectedFound, audit2ResultFound, false);
-        String expectedFound = readFile("expectedFound.json");
-        String resultFound = cutCrudResource.find("country", "1.0.0", false, readFile("resultFound.json")).getEntity().toString();
-        JSONAssert.assertEquals(expectedFound, resultFound, false); // #TODO #FIX Not finding the right version
+    // insert country data
+    LOGGER.debug("Insert country");
+    cutCrudResource.insert("country", "1.0.0", readFile("resultInserted.json")).getEntity();
+    LOGGER.debug("country inserted");
 
-        String expectedAll = cutCrudResource.find("country", "1.0.0", false, readFile("country-noq.json")).getEntity().toString();
-        System.out.println("returnVAlue:" + expectedAll);
-        JSONAssert.assertEquals(expectedFound, expectedAll, false);
+    // insert saved search
+    LOGGER.debug("Insert savedSearch");
+    cutCrudResource.insert("savedSearch", "1.0.0",
+        "{'data':{'name':'test','entity':'country','parameters':[{'name':'iso'}],'query':{'field':'iso2code','op':'=','rvalue':'${iso}'}}}".
+            replaceAll("'", "\""));
+    LOGGER.debug("savedSearch inserted");
 
-        String resultSimpleFound = cutCrudResource.simpleFind( //?Q&P&S&from&to
-                "country",
-                "1.0.0",
-                "iso2code:CA,QE;iso2code:CA;iso2code:CA,EN",
-                "name:1r,iso3code:1,iso2code:0r",
-                "name:a,iso3code:d,iso2code:d",
-                0l,
-                100l,null).getEntity().toString();
-        JSONAssert.assertEquals(expectedFound, resultSimpleFound, false);
+    // Run saved search
+    String result = cutCrudResource.runSavedSearch("country", "1.0.0", "test", null, null, null,
+        null, null, "{'iso':'CA'}".replaceAll("'", "\"")).getEntity().toString();
+    assertNotEquals(-1, result.indexOf("\"matchCount\":1"));
+    LOGGER.debug("result:" + result);
 
-         resultSimpleFound = cutCrudResource.simpleFind( //?Q&P&S&from&to
-                "country",
-                "1.0.0",
-                "iso2code:CA,QE;iso2code:CA;iso2code:CA,EN",
-                "name:1r,iso3code:1,iso2code:0r",
-                "name:a,iso3code:d,iso2code:d",
-                0l,
-                null,1l).getEntity().toString();
-        JSONAssert.assertEquals(expectedFound, resultSimpleFound, false);
+  }
 
-        String resultSimpleFromToNotSetFound = cutCrudResource.simpleFind( //?Q&P&S&from&to
-                "country",
-                "1.0.0",
-                "iso2code:CA,QE;iso2code:CA;iso2code:CA,EN",
-                "name:1r,iso3code:1,iso2code:0r",
-                "name:a,iso3code:d,iso2code:d",
-                null,
-                null,null).getEntity().toString();
-        JSONAssert.assertEquals(expectedFound, resultSimpleFromToNotSetFound, false);
+  @Test
+  public void testListSavedSearch()
+      throws IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException, URISyntaxException {
+    Assert.assertNotNull("CrudResource was not injected by the container", cutCrudResource);
 
-        String expectedDeleted = readFile("expectedDeleted.json");
-        String resultDeleted = cutCrudResource.delete("country", "1.0.0", readFile("resultDeleted.json")).getEntity().toString();
-        JSONAssert.assertEquals(expectedDeleted, resultDeleted, false);
+    // Saved search metadata
+    LOGGER.debug("Insert saved search md");
+    String metadata = readFile("lb-saved-search.json");
+    EntityMetadata em = RestConfiguration.getFactory().getJSONParser()
+        .parseEntityMetadata(JsonUtils.json(metadata));
+    RestConfiguration.getFactory().getMetadata().createNewMetadata(em);
+    LOGGER.debug("saved search md inserted");
 
-        String expectedFound2 = readFile("expectedFound2.json");
-        String resultFound2 = cutCrudResource.find("country", "1.0.0", false,readFile("resultFound2.json")).getEntity().toString();
-        JSONAssert.assertEquals(expectedFound2, resultFound2, false);
-    }
+    // insert saved search
+    LOGGER.debug("Insert savedSearch");
+    cutCrudResource.insert("savedSearch", "1.0.0",
+        "{'data':{'name':'test','entity':'country','parameters':[{'name':'iso'}],'query':{'field':'iso2code','op':'=','rvalue':'${iso}'}}}".
+            replaceAll("'", "\""));
+    LOGGER.debug("savedSearch inserted");
 
-    @Test
-    public void testLock() throws IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException, URISyntaxException, JSONException {
-        Assert.assertNotNull("CrudResource was not injected by the container", cutCrudResource);
-        String result = cutCrudResource.acquire("test", "caller", "resource", null).getEntity().toString();
-        Assert.assertEquals("{\"result\":true}", result);
-    }
+    // get saved search
+    String result = cutCrudResource.getSearchesForEntity("country", null, null).getEntity()
+        .toString();
+    assertNotEquals(-1, result.indexOf("\"matchCount\":1"));
+    LOGGER.debug("result:" + result);
 
-    @Test
-    public void testLockWithPost() throws IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException, URISyntaxException, JSONException {
-        Assert.assertNotNull("CrudResource was not injected by the container", cutCrudResource);
+  }
 
-        String request =
-                "{" +
-                        "\"operation\" : \"acquire\"," +
-                        "\"domain\" : \"test\"," +
-                        "\"callerId\" : \"caller\"," +
-                        "\"resourceId\" : \"resource/slash\"" +
-                        "}";
+  @Test
+  @RunAsClient
+  public void testDiagnosticsCheckAsClient(@ArquillianResource URL url) throws Exception {
+    ClientRequest request = new ClientRequest(UriBuilder.fromUri(url.toURI())
+        .path("diagnostics")
+        .build()
+        .toString());
+    request.accept(MediaType.APPLICATION_JSON);
+    ClientResponse<String> response = request.get(String.class);
+    ObjectNode jsonNode = (ObjectNode) new ObjectMapper().readTree(response.getEntity());
 
-        String result = cutCrudResource.lock(request).getEntity().toString();
-        Assert.assertEquals("{\"result\":true}", result);
-    }
+    LOGGER.debug(
+        "DiagnosticCheckMessage: " + jsonNode.elements().next().get("message").asText());
+    assertTrue(jsonNode.elements().next().get("healthy").asBoolean());
+  }
 
-    @Test
-    public void testGenerate() throws IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException, URISyntaxException, JSONException {
-        Assert.assertNotNull("CrudResource was not injected by the container", cutCrudResource);
-        String metadata = readFile("generator-md.json");
-        EntityMetadata em = RestConfiguration.getFactory().getJSONParser().parseEntityMetadata(JsonUtils.json(metadata));
-        RestConfiguration.getFactory().getMetadata().createNewMetadata(em);
+  @Test
+  @RunAsClient
+  public void testHealthCheckAsClient(@ArquillianResource URL url) throws Exception {
+    ClientRequest request = new ClientRequest(UriBuilder.fromUri(url.toURI())
+        .path("diagnostics")
+        .build()
+        .toString());
+    request.accept(MediaType.APPLICATION_JSON);
+    ClientResponse<String> response = request.get(String.class);
+    ObjectNode jsonNode = (ObjectNode) new ObjectMapper().readTree(response.getEntity());
 
-        String result = cutCrudResource.generate("generate", "1.0.0", "number", 1).getEntity().toString();
-        System.out.println("Generated:" + result);
-        JSONAssert.assertEquals("{\"processed\":[\"50000000\"]}", result, false);
-
-        result = cutCrudResource.generate("generate", "number", 3).getEntity().toString();
-        System.out.println("Generated:" + result);
-        JSONAssert.assertEquals("{\"processed\":[\"50000001\",\"50000002\",\"50000003\"]}", result, false);
-    }
-
-    @Test
-    public void testSavedSearch() throws IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException, URISyntaxException, JSONException {
-        Assert.assertNotNull("CrudResource was not injected by the container", cutCrudResource);
-
-        // Saved search metadata
-        System.out.println("Insert saved search md");
-        String metadata = readFile("lb-saved-search.json");
-        EntityMetadata em = RestConfiguration.getFactory().getJSONParser().parseEntityMetadata(JsonUtils.json(metadata));
-        RestConfiguration.getFactory().getMetadata().createNewMetadata(em);
-        System.out.println("saved search md inserted");
-
-        // Country metadata
-        System.out.println("Insert country md");
-        metadata = readFile("metadata.json");
-        em = RestConfiguration.getFactory().getJSONParser().parseEntityMetadata(JsonUtils.json(metadata));
-        RestConfiguration.getFactory().getMetadata().createNewMetadata(em);
-        System.out.println("country md inserted");
-        String auditMetadata = FileUtil.readFile("metadata/audit.json");
-        EntityMetadata aEm = RestConfiguration.getFactory().getJSONParser().parseEntityMetadata(JsonUtils.json(auditMetadata));
-        RestConfiguration.getFactory().getMetadata().createNewMetadata(aEm);
-
-        // insert country data
-        System.out.println("Insert country");
-        cutCrudResource.insert("country", "1.0.0", readFile("resultInserted.json")).getEntity().toString();
-        System.out.println("country inserted");
-
-        // insert saved search
-        System.out.println("Insert savedSearch");
-        cutCrudResource.insert("savedSearch","1.0.0","{'data':{'name':'test','entity':'country','parameters':[{'name':'iso'}],'query':{'field':'iso2code','op':'=','rvalue':'${iso}'}}}".
-                               replaceAll("'","\""));
-        System.out.println("savedSearch inserted");
-
-        // Run saved search
-        String result = cutCrudResource.runSavedSearch("country","1.0.0","test",null,null,null,null,null,"{'iso':'CA'}".replaceAll("'","\"")).getEntity().toString();
-        assertTrue(result.indexOf("\"matchCount\":1")!=-1);
-        System.out.println("result:" + result);
-
-    }
-
-    @Test
-    public void testListSavedSearch() throws IOException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException, URISyntaxException, JSONException {
-        Assert.assertNotNull("CrudResource was not injected by the container", cutCrudResource);
-
-        // Saved search metadata
-        System.out.println("Insert saved search md");
-        String metadata = readFile("lb-saved-search.json");
-        EntityMetadata em = RestConfiguration.getFactory().getJSONParser().parseEntityMetadata(JsonUtils.json(metadata));
-        RestConfiguration.getFactory().getMetadata().createNewMetadata(em);
-        System.out.println("saved search md inserted");
-
-        // insert saved search
-        System.out.println("Insert savedSearch");
-        cutCrudResource.insert("savedSearch","1.0.0","{'data':{'name':'test','entity':'country','parameters':[{'name':'iso'}],'query':{'field':'iso2code','op':'=','rvalue':'${iso}'}}}".
-                               replaceAll("'","\""));
-        System.out.println("savedSearch inserted");
-
-        // get saved search
-        String result = cutCrudResource.getSearchesForEntity("country",null,null).getEntity().toString();
-        assertTrue(result.indexOf("\"matchCount\":1")!=-1);
-        System.out.println("result:" + result);
-
-    }
-
-    @Test
-    @RunAsClient
-    public void testDiagnosticsCheckAsClient(@ArquillianResource URL url) throws Exception {
-        ClientRequest request = new ClientRequest(UriBuilder.fromUri(url.toURI())
-                .path("diagnostics")
-                .build()
-                .toString());
-        request.accept(MediaType.APPLICATION_JSON);
-        ClientResponse<String> response = request.get(String.class);
-        ObjectNode jsonNode = (ObjectNode) new ObjectMapper().readTree(response.getEntity());
-
-        System.out.println("DiagnosticCheckMessage: " + jsonNode.elements().next().get("message").asText());
-        assertTrue(jsonNode.elements().next().get("healthy").asBoolean());
-    }
-
-    @Test
-    @RunAsClient
-    public void testHealthCheckAsClient(@ArquillianResource URL url) throws Exception {
-        ClientRequest request = new ClientRequest(UriBuilder.fromUri(url.toURI())
-                .path("diagnostics")
-                .build()
-                .toString());
-        request.accept(MediaType.APPLICATION_JSON);
-        ClientResponse<String> response = request.get(String.class);
-        ObjectNode jsonNode = (ObjectNode) new ObjectMapper().readTree(response.getEntity());
-
-        System.out.println("HealthCheckMessage: " + jsonNode.elements().next().get("message").asText());
-        assertTrue(jsonNode.elements().next().get("healthy").asBoolean());
-    }
+    LOGGER.debug("HealthCheckMessage: " + jsonNode.elements().next().get("message").asText());
+    assertTrue(jsonNode.elements().next().get("healthy").asBoolean());
+  }
 
 }

--- a/metadata/src/test/java/com/redhat/lightblue/rest/metadata/ITCaseMetadataResourceTest.java
+++ b/metadata/src/test/java/com/redhat/lightblue/rest/metadata/ITCaseMetadataResourceTest.java
@@ -20,32 +20,40 @@ package com.redhat.lightblue.rest.metadata;
 
 import static com.redhat.lightblue.util.test.FileUtil.readFile;
 
+import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 import com.mongodb.MongoClient;
+import com.redhat.lightblue.config.MetadataConfiguration;
 import com.redhat.lightblue.mongo.config.MongoConfiguration;
-import de.flapdoodle.embed.mongo.Command;
+import com.redhat.lightblue.mongo.metadata.MongoMetadata;
+import com.redhat.lightblue.rest.RestConfiguration;
+import com.redhat.lightblue.rest.test.RestConfigurationRule;
+import com.redhat.lightblue.rest.test.support.Assets;
+import com.redhat.lightblue.rest.test.support.CrudWebXmls;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
 import de.flapdoodle.embed.mongo.MongodStarter;
 import de.flapdoodle.embed.mongo.config.Defaults;
 import de.flapdoodle.embed.mongo.config.MongodConfig;
 import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.packageresolver.Command;
 import de.flapdoodle.embed.process.config.RuntimeConfig;
-import de.flapdoodle.embed.process.config.io.ProcessOutput;
 import de.flapdoodle.embed.process.config.store.TimeoutConfig;
-import de.flapdoodle.embed.process.io.Processors;
+import de.flapdoodle.embed.process.extract.DirectoryAndExecutableNaming;
+import de.flapdoodle.embed.process.extract.UserTempNaming;
 import de.flapdoodle.embed.process.io.StreamProcessor;
+import de.flapdoodle.embed.process.io.directories.PlatformTempDir;
 import de.flapdoodle.embed.process.runtime.Network;
+import de.flapdoodle.embed.process.store.Downloader;
+import de.flapdoodle.embed.process.store.ExtractedArtifactStore;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
-
 import java.time.Duration;
 import javax.inject.Inject;
 import javax.ws.rs.core.SecurityContext;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -54,7 +62,6 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.json.JSONException;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -62,278 +69,291 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import com.mongodb.BasicDBObject;
-import com.redhat.lightblue.config.MetadataConfiguration;
-import com.redhat.lightblue.mongo.metadata.MongoMetadata;
-import com.redhat.lightblue.mongo.test.EmbeddedMongo;
-import com.redhat.lightblue.rest.RestConfiguration;
-import com.redhat.lightblue.rest.test.RestConfigurationRule;
-import com.redhat.lightblue.rest.test.support.Assets;
-import com.redhat.lightblue.rest.test.support.CrudWebXmls;
-
 /**
  * @author lcestari
  */
 @RunWith(Arquillian.class)
 public class ITCaseMetadataResourceTest {
 
-    @Rule
-    public final RestConfigurationRule resetRuleConfiguration = new RestConfigurationRule();
+  @Rule
+  public final RestConfigurationRule resetRuleConfiguration = new RestConfigurationRule();
 
-    public static class FileStreamProcessor implements StreamProcessor {
-        private final FileOutputStream outputStream;
+  public static class FileStreamProcessor implements StreamProcessor {
 
-        public FileStreamProcessor(File file) throws FileNotFoundException {
-            outputStream = new FileOutputStream(file);
-        }
+    private final FileOutputStream outputStream;
 
+    public FileStreamProcessor(File file) throws FileNotFoundException {
+      outputStream = new FileOutputStream(file);
+    }
+
+    @Override
+    public void process(String block) {
+      try {
+        outputStream.write(block.getBytes());
+      } catch (IOException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+
+    @Override
+    public void onProcessed() {
+      try {
+        outputStream.close();
+      } catch (IOException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+
+  }
+
+  private static final String MONGO_HOST = "localhost";
+  private static final int MONGO_PORT = 27757;
+  private static final String IN_MEM_CONNECTION_URL = MONGO_HOST + ":" + MONGO_PORT;
+
+  private static final String DB_NAME = "mongo";
+
+  private static MongodExecutable mongodExe;
+  private static MongodProcess mongod;
+  private static MongoClient mongo;
+  private static DB db;
+
+  static {
+    try {
+      RuntimeConfig runtimeConfig = Defaults.runtimeConfigFor(Command.MongoD)
+          .artifactStore(ExtractedArtifactStore.builder()
+              .extraction(DirectoryAndExecutableNaming.builder()
+                  .executableNaming(new UserTempNaming())
+                  .directory(new PlatformTempDir()).build())
+              .downloader(Downloader.platformDefault())
+              .temp(DirectoryAndExecutableNaming.builder()
+                  .executableNaming(new UserTempNaming())
+                  .directory(new PlatformTempDir()).build())
+              .downloadConfig(Defaults.downloadConfigFor(Command.MongoD)
+                  .timeoutConfig(TimeoutConfig.builder()
+                      .connectionTimeout((int) Duration.ofMinutes(1).toMillis())
+                      .readTimeout((int) Duration.ofMinutes(5).toMillis())
+                      .build())
+                  .fileNaming(new UserTempNaming()).build())
+              .build())
+          .build();
+
+      MongodStarter runtime = MongodStarter.getInstance(runtimeConfig);
+      mongodExe = runtime.prepare(
+          MongodConfig.builder()
+              .version(de.flapdoodle.embed.mongo.distribution.Version.V5_0_2)
+              .net(new Net(MONGO_PORT, Network.localhostIsIPv6()))
+              .build()
+      );
+      try {
+        mongod = mongodExe.start();
+      } catch (Throwable t) {
+        // try again, could be killed breakpoint in IDE
+        mongod = mongodExe.start();
+      }
+      mongo = new MongoClient(IN_MEM_CONNECTION_URL);
+
+      MongoConfiguration config = new MongoConfiguration();
+      // disable ssl for test (enabled by default)
+      config.setDatabase(DB_NAME);
+      config.setSsl(Boolean.FALSE);
+      config.addServerAddress(MONGO_HOST, MONGO_PORT);
+
+      db = config.getDB();
+
+      Runtime.getRuntime().addShutdownHook(new Thread() {
         @Override
-        public void process(String block) {
-            try {
-                outputStream.write(block.getBytes());
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
+        public void run() {
+          super.run();
+          clearDatabase();
         }
 
-        @Override
-        public void onProcessed() {
-            try {
-                outputStream.close();
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
-        }
-
+      });
+    } catch (IOException e) {
+      throw new java.lang.Error(e);
     }
+  }
 
-    private static final String MONGO_HOST = "localhost";
-    private static final int MONGO_PORT = 27757;
-    private static final String IN_MEM_CONNECTION_URL = MONGO_HOST + ":" + MONGO_PORT;
+  @Before
+  public void setup() {
+    db.createCollection(MongoMetadata.DEFAULT_METADATA_COLLECTION, null);
+    BasicDBObject index = new BasicDBObject("name", 1);
+    index.put("version.value", 1);
+    db.getCollection(MongoMetadata.DEFAULT_METADATA_COLLECTION).createIndex(index, "name", true);
+  }
 
-    private static final String DB_NAME = "mongo";
-
-    private static MongodExecutable mongodExe;
-    private static MongodProcess mongod;
-    private static MongoClient mongo;
-    private static DB db;
-
-    static {
-        try {
-            StreamProcessor mongodOutput = Processors.named("[mongod>]",
-                new FileStreamProcessor(File.createTempFile("mongod", "log")));
-            StreamProcessor mongodError = new FileStreamProcessor(File.createTempFile("mongod-error", "log"));
-            StreamProcessor commandsOutput = Processors.namedConsole("[console>]");
-
-            Command mongoD = Command.MongoD;
-            RuntimeConfig runtimeConfig = Defaults.runtimeConfigFor(mongoD)
-                .processOutput(new ProcessOutput(mongodOutput, mongodError, commandsOutput))
-                .artifactStore(Defaults.extractedArtifactStoreFor(mongoD)
-                    .withDownloadConfig(Defaults.downloadConfigFor(mongoD)
-                        .timeoutConfig(TimeoutConfig.builder()
-                            .connectionTimeout((int) Duration.ofMinutes(1).toMillis())
-                            .readTimeout((int) Duration.ofMinutes(5).toMillis())
-                            .build()).build()))
-                .build();
-
-            MongodStarter runtime = MongodStarter.getInstance(runtimeConfig);
-            mongodExe = runtime.prepare(
-                MongodConfig.builder()
-                    .version(de.flapdoodle.embed.mongo.distribution.Version.V3_1_6)
-                    .net(new Net(MONGO_PORT, Network.localhostIsIPv6()))
-                    .build()
-            );
-            try {
-                mongod = mongodExe.start();
-            } catch (Throwable t) {
-                // try again, could be killed breakpoint in IDE
-                mongod = mongodExe.start();
-            }
-            MongoClient mongoClient = new MongoClient(IN_MEM_CONNECTION_URL);
-            mongo = mongoClient;
-
-            MongoConfiguration config = new MongoConfiguration();
-            // disable ssl for test (enabled by default)
-            config.setDatabase(DB_NAME);
-            config.setSsl(Boolean.FALSE);
-            config.addServerAddress(MONGO_HOST, MONGO_PORT);
-
-            db = config.getDB();
-
-            Runtime.getRuntime().addShutdownHook(new Thread() {
-                @Override
-                public void run() {
-                    super.run();
-                    clearDatabase();
-                }
-
-            });
-        } catch (IOException e) {
-            throw new java.lang.Error(e);
-        }
+  @After
+  public void teardown() {
+    if (mongo != null) {
+      mongo.dropDatabase(DB_NAME);
     }
+  }
 
-    @Before
-    public void setup() throws Exception {
-        db.createCollection(MongoMetadata.DEFAULT_METADATA_COLLECTION, null);
-        BasicDBObject index = new BasicDBObject("name", 1);
-        index.put("version.value", 1);
-        db.getCollection(MongoMetadata.DEFAULT_METADATA_COLLECTION).createIndex(index, "name", true);
+  public static void clearDatabase() {
+    if (mongod != null) {
+      mongod.stop();
+      mongodExe.stop();
     }
+    db = null;
+    mongo = null;
+    mongod = null;
+    mongodExe = null;
+  }
 
-    @After
-    public void teardown() {
-        if (mongo != null) {
-            mongo.dropDatabase(DB_NAME);
-        }
+  @Deployment
+  public static WebArchive createDeployment() throws Exception {
+    File[] libs = Maven.resolver().loadPomFromFile("pom.xml").importRuntimeDependencies().resolve()
+        .withTransitivity().asFile();
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "lightblue.war")
+        .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+        .addAsWebInfResource(
+            Assets.forDocument(CrudWebXmls.forNonEE6Container(RestApplication.class)), "web.xml")
+        .addAsLibraries(Maven.configureResolver()
+            .workOffline()
+            .loadPomFromFile("pom.xml")
+            .resolve("org.jboss.weld.servlet:weld-servlet")
+            .withTransitivity()
+            .asFile())
+        .addPackages(true, "com.redhat.lightblue")
+        .addAsResource(new File("src/test/resources/lightblue-metadata.json"),
+            MetadataConfiguration.FILENAME)
+        .addAsResource(new File("src/test/resources/datasources.json"), "datasources.json")
+        .addAsResource(EmptyAsset.INSTANCE, "resources/test.properties");
+
+    for (File file : libs) {
+      archive.addAsLibrary(file);
     }
+    return archive;
 
-    public static void clearDatabase() {
-        if (mongod != null) {
-            mongod.stop();
-            mongodExe.stop();
-        }
-        db = null;
-        mongo = null;
-        mongod = null;
-        mongodExe = null;
-    }
+  }
 
-    @Deployment
-    public static WebArchive createDeployment() throws Exception {
-        File[] libs = Maven.resolver().loadPomFromFile("pom.xml").importRuntimeDependencies().resolve().withTransitivity().asFile();
+  private String esc(String s) {
+    return s.replace("'", "\"");
+  }
 
-        WebArchive archive = ShrinkWrap.create(WebArchive.class, "lightblue.war")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-                .addAsWebInfResource(Assets.forDocument(CrudWebXmls.forNonEE6Container(RestApplication.class)), "web.xml")
-                .addAsLibraries(Maven.configureResolver()
-                        .workOffline()
-                        .loadPomFromFile("pom.xml")
-                        .resolve("org.jboss.weld.servlet:weld-servlet")
-                        .withTransitivity()
-                        .asFile())
-                .addPackages(true, "com.redhat.lightblue")
-                .addAsResource(new File("src/test/resources/lightblue-metadata.json"), MetadataConfiguration.FILENAME)
-                .addAsResource(new File("src/test/resources/datasources.json"), "datasources.json")
-                .addAsResource(EmptyAsset.INSTANCE, "resources/test.properties");
+  @Inject
+  private AbstractMetadataResource cutMetadataResource;
 
-        for (File file : libs) {
-            archive.addAsLibrary(file);
-        }
-        return archive;
+  @Test
+  public void testFirstIntegrationTest() throws IOException, URISyntaxException, JSONException {
+    Assert.assertNotNull("MetadataResource was not injected by the container", cutMetadataResource);
 
-    }
+    SecurityContext sc = new TestSecurityContext();
 
-    private String esc(String s) {
-        return s.replace("'", "\"");
-    }
+    System.out.println("factory:" + RestConfiguration.getFactory());
+    String expectedCreated = readFile("expectedCreated.json");
+    String resultCreated = cutMetadataResource.createMetadata(sc, "country", "1.0.0",
+        readFile("resultCreated.json"));
+    JSONAssert.assertEquals(expectedCreated, resultCreated, false);
 
-    @Inject
-    private AbstractMetadataResource cutMetadataResource;
+    String expectedDepGraph = readFile("expectedDepGraph.json").replace("Notsupportedyet",
+        " Not supported yet");
+    String resultDepGraph = cutMetadataResource.getDepGraph(sc);
+    JSONAssert.assertEquals(expectedDepGraph, resultDepGraph, false);
 
-    @Test
-    public void testFirstIntegrationTest() throws IOException, URISyntaxException, JSONException {
-        Assert.assertNotNull("MetadataResource was not injected by the container", cutMetadataResource);
+    String expectedDepGraph1 = readFile("expectedDepGraph1.json").replace("Notsupportedyet",
+        " Not supported yet");
+    String resultDepGraph1 = cutMetadataResource.getDepGraph(sc, "country");
+    JSONAssert.assertEquals(expectedDepGraph1, resultDepGraph1, false);
 
-        SecurityContext sc = new TestSecurityContext();
+    String expectedDepGraph2 = readFile("expectedDepGraph2.json").replace("Notsupportedyet",
+        " Not supported yet");
+    String resultDepGraph2 = cutMetadataResource.getDepGraph(sc, "country", "1.0.0");
+    JSONAssert.assertEquals(expectedDepGraph2, resultDepGraph2, false);
 
-        System.out.println("factory:" + RestConfiguration.getFactory());
-        String expectedCreated = readFile("expectedCreated.json");
-        String resultCreated = cutMetadataResource.createMetadata(sc, "country", "1.0.0", readFile("resultCreated.json"));
-        JSONAssert.assertEquals(expectedCreated, resultCreated, false);
+    String expectedEntityNames = "{\"entities\":[\"country\"]}";
+    String resultEntityNames = cutMetadataResource.getEntityNames(sc);
+    JSONAssert.assertEquals(expectedEntityNames, resultEntityNames, false);
 
-        String expectedDepGraph = readFile("expectedDepGraph.json").replace("Notsupportedyet", " Not supported yet");
-        String resultDepGraph = cutMetadataResource.getDepGraph(sc);
-        JSONAssert.assertEquals(expectedDepGraph, resultDepGraph, false);
+    // no default version
+    String expectedEntityRoles = esc(
+        "{'status':'ERROR','modifiedCount':0,'matchCount':0,'dataErrors':[{'data':{'name':'country'},'errors':[{'objectType':'error','context':'GetEntityRolesCommand','errorCode':'ERR_NO_METADATA','msg':'Could not get metadata for given input. Error message: version'}]}]}");
+    String expectedEntityRoles1 = esc(
+        "{'status':'ERROR','modifiedCount':0,'matchCount':0,'dataErrors':[{'data':{'name':'country'},'errors':[{'objectType':'error','context':'GetEntityRolesCommand/country','errorCode':'ERR_NO_METADATA','msg':'Could not get metadata for given input. Error message: version'}]}]}");
+    String resultEntityRoles = cutMetadataResource.getEntityRoles(sc);
+    String resultEntityRoles1 = cutMetadataResource.getEntityRoles(sc, "country");
+    JSONAssert.assertEquals(expectedEntityRoles, resultEntityRoles, false);
+    JSONAssert.assertEquals(expectedEntityRoles1, resultEntityRoles1, false);
 
-        String expectedDepGraph1 = readFile("expectedDepGraph1.json").replace("Notsupportedyet", " Not supported yet");
-        String resultDepGraph1 = cutMetadataResource.getDepGraph(sc, "country");
-        JSONAssert.assertEquals(expectedDepGraph1, resultDepGraph1, false);
+    String expectedEntityRoles2 = readFile("expectedEntityRoles2.json");
+    String resultEntityRoles2 = cutMetadataResource.getEntityRoles(sc, "country", "1.0.0");
+    JSONAssert.assertEquals(expectedEntityRoles2, resultEntityRoles2, false);
 
-        String expectedDepGraph2 = readFile("expectedDepGraph2.json").replace("Notsupportedyet", " Not supported yet");
-        String resultDepGraph2 = cutMetadataResource.getDepGraph(sc, "country", "1.0.0");
-        JSONAssert.assertEquals(expectedDepGraph2, resultDepGraph2, false);
+    String expectedEntityVersions = esc("[{'version':'1.0.0','changelog':'blahblah'}]");
+    String resultEntityVersions = cutMetadataResource.getEntityVersions(sc, "country");
+    JSONAssert.assertEquals(expectedEntityVersions, resultEntityVersions, false);
 
-        String expectedEntityNames = "{\"entities\":[\"country\"]}";
-        String resultEntityNames = cutMetadataResource.getEntityNames(sc);
-        JSONAssert.assertEquals(expectedEntityNames, resultEntityNames, false);
+    String expectedGetMetadata = esc(
+        "{'entityInfo':{'name':'country','indexes':[{'name':null,'unique':true,'fields':[{'field':'name','dir':'$asc'}]},{'name': null,'unique': true,'fields': [{'field': '_id','dir': '$asc'}]}],'datastore':{'backend':'mongo','datasource':'mongo','collection':'country'}},'schema':{'name':'country','version':{'value':'1.0.0','changelog':'blahblah'},'status':{'value':'active'},'access':{'insert':['anyone'],'update':['anyone'],'find':['anyone'],'delete':['anyone']},'fields':{'iso3code':{'type':'string'},'name':{'type':'string'},'iso2code':{'type':'string'},'objectType':{'type':'string','access':{'find':['anyone'],'update':['noone']},'constraints':{'required':true,'minLength':1}}}}}");
+    String resultGetMetadata = cutMetadataResource.getMetadata(sc, "country", "1.0.0");
+    JSONAssert.assertEquals(expectedGetMetadata, resultGetMetadata, false);
 
-        // no default version
-        String expectedEntityRoles = esc("{'status':'ERROR','modifiedCount':0,'matchCount':0,'dataErrors':[{'data':{'name':'country'},'errors':[{'objectType':'error','context':'GetEntityRolesCommand','errorCode':'ERR_NO_METADATA','msg':'Could not get metadata for given input. Error message: version'}]}]}");
-        String expectedEntityRoles1 = esc("{'status':'ERROR','modifiedCount':0,'matchCount':0,'dataErrors':[{'data':{'name':'country'},'errors':[{'objectType':'error','context':'GetEntityRolesCommand/country','errorCode':'ERR_NO_METADATA','msg':'Could not get metadata for given input. Error message: version'}]}]}");
-        String resultEntityRoles = cutMetadataResource.getEntityRoles(sc);
-        String resultEntityRoles1 = cutMetadataResource.getEntityRoles(sc, "country");
-        JSONAssert.assertEquals(expectedEntityRoles, resultEntityRoles, false);
-        JSONAssert.assertEquals(expectedEntityRoles1, resultEntityRoles1, false);
+    String expectedCreateSchema = readFile("expectedCreateSchema.json");
+    String resultCreateSchema = cutMetadataResource.createSchema(sc, "country", "1.1.0",
+        readFile("expectedCreateSchemaInput.json"));
+    JSONAssert.assertEquals(expectedCreateSchema, resultCreateSchema, false);
 
-        String expectedEntityRoles2 = readFile("expectedEntityRoles2.json");
-        String resultEntityRoles2 = cutMetadataResource.getEntityRoles(sc, "country", "1.0.0");
-        JSONAssert.assertEquals(expectedEntityRoles2, resultEntityRoles2, false);
+    String expectedUpdateEntityInfo = readFile("expectedUpdateEntityInfo.json");
+    String resultUpdateEntityInfo = cutMetadataResource.updateEntityInfo(sc, "country",
+        readFile("expectedUpdateEntityInfoInput.json"));
+    JSONAssert.assertEquals(expectedUpdateEntityInfo, resultUpdateEntityInfo, false);
 
-        String expectedEntityVersions = esc("[{'version':'1.0.0','changelog':'blahblah'}]");
-        String resultEntityVersions = cutMetadataResource.getEntityVersions(sc, "country");
-        JSONAssert.assertEquals(expectedEntityVersions, resultEntityVersions, false);
+    String x = cutMetadataResource.setDefaultVersion(sc, "country", "1.0.0");
+    String expected = esc(
+        "{'entityInfo':{'name':'country','defaultVersion':'1.0.0','indexes':[{'name':null,'unique':true,'fields':[{'field':'name','dir':'$asc'}]},{'name': null,'unique': true,'fields': [{'field': '_id','dir': '$asc'}]}],'datastore':{'backend':'mongo','datasource':'mongo','collection':'country'}},'schema':{'name':'country','version':{'value':'1.0.0','changelog':'blahblah'},'status':{'value':'active'},'access':{'insert':['anyone'],'update':['anyone'],'find':['anyone'],'delete':['anyone']},'fields':{'iso3code':{'type':'string'},'name':{'type':'string'},'iso2code':{'type':'string'},'objectType':{'type':'string','access':{'find':['anyone'],'update':['noone']},'constraints':{'required':true,'minLength':1}}}}}");
+    JSONAssert.assertEquals(expected, x, false);
 
-        String expectedGetMetadata = esc("{'entityInfo':{'name':'country','indexes':[{'name':null,'unique':true,'fields':[{'field':'name','dir':'$asc'}]},{'name': null,'unique': true,'fields': [{'field': '_id','dir': '$asc'}]}],'datastore':{'backend':'mongo','datasource':'mongo','collection':'country'}},'schema':{'name':'country','version':{'value':'1.0.0','changelog':'blahblah'},'status':{'value':'active'},'access':{'insert':['anyone'],'update':['anyone'],'find':['anyone'],'delete':['anyone']},'fields':{'iso3code':{'type':'string'},'name':{'type':'string'},'iso2code':{'type':'string'},'objectType':{'type':'string','access':{'find':['anyone'],'update':['noone']},'constraints':{'required':true,'minLength':1}}}}}");
-        String resultGetMetadata = cutMetadataResource.getMetadata(sc, "country", "1.0.0");
-        JSONAssert.assertEquals(expectedGetMetadata, resultGetMetadata, false);
+    x = cutMetadataResource.clearDefaultVersion(sc, "country");
+    //System.out.println(x);
+    expected = esc(
+        "{'name':'country','indexes':[{'name':null,'unique':true,'fields':[{'field':'name','dir':'$asc'}]},{'name': null,'unique': true,'fields': [{'field': '_id','dir': '$asc'}]}],'datastore':{'backend':'mongo','datasource':'mongo','collection':'country'}}");
+    JSONAssert.assertEquals(expected, x, false);
 
-        String expectedCreateSchema = readFile("expectedCreateSchema.json");
-        String resultCreateSchema = cutMetadataResource.createSchema(sc, "country", "1.1.0", readFile("expectedCreateSchemaInput.json"));
-        JSONAssert.assertEquals(expectedCreateSchema, resultCreateSchema, false);
+    String expectedUpdateSchemaStatus = esc(
+        "{'entityInfo':{'name':'country','indexes':[{'name':null,'unique':true,'fields':[{'field':'name','dir':'$asc'}]},{'name': null,'unique': true,'fields': [{'field': '_id','dir': '$asc'}]}],'datastore':{'backend':'mongo','datasource':'mongo','collection':'country'}},'schema':{'name':'country','version':{'value':'1.0.0','changelog':'blahblah'},'status':{'value':'deprecated'},'access':{'insert':['anyone'],'update':['anyone'],'find':['anyone'],'delete':['anyone']},'fields':{'iso3code':{'type':'string'},'name':{'type':'string'},'iso2code':{'type':'string'},'objectType':{'type':'string','access':{'find':['anyone'],'update':['noone']},'constraints':{'required':true,'minLength':1}}}}}");
+    String resultUpdateSchemaStatus = cutMetadataResource.updateSchemaStatus(sc, "country", "1.0.0",
+        "deprecated", "No comment");
+    JSONAssert.assertEquals(expectedUpdateSchemaStatus, resultUpdateSchemaStatus, false);
 
-        String expectedUpdateEntityInfo = readFile("expectedUpdateEntityInfo.json");
-        String resultUpdateEntityInfo = cutMetadataResource.updateEntityInfo(sc, "country", readFile("expectedUpdateEntityInfoInput.json"));
-        JSONAssert.assertEquals(expectedUpdateEntityInfo, resultUpdateEntityInfo, false);
+  }
 
-        String x = cutMetadataResource.setDefaultVersion(sc, "country", "1.0.0");
-        String expected = esc("{'entityInfo':{'name':'country','defaultVersion':'1.0.0','indexes':[{'name':null,'unique':true,'fields':[{'field':'name','dir':'$asc'}]},{'name': null,'unique': true,'fields': [{'field': '_id','dir': '$asc'}]}],'datastore':{'backend':'mongo','datasource':'mongo','collection':'country'}},'schema':{'name':'country','version':{'value':'1.0.0','changelog':'blahblah'},'status':{'value':'active'},'access':{'insert':['anyone'],'update':['anyone'],'find':['anyone'],'delete':['anyone']},'fields':{'iso3code':{'type':'string'},'name':{'type':'string'},'iso2code':{'type':'string'},'objectType':{'type':'string','access':{'find':['anyone'],'update':['noone']},'constraints':{'required':true,'minLength':1}}}}}");
-        JSONAssert.assertEquals(expected, x, false);
+  @Test
+  public void createMetadataAlsoUpdates() throws Exception {
+    Assert.assertNotNull("MetadataResource was not injected by the container", cutMetadataResource);
 
-        x = cutMetadataResource.clearDefaultVersion(sc, "country");
-        //System.out.println(x);
-        expected = esc("{'name':'country','indexes':[{'name':null,'unique':true,'fields':[{'field':'name','dir':'$asc'}]},{'name': null,'unique': true,'fields': [{'field': '_id','dir': '$asc'}]}],'datastore':{'backend':'mongo','datasource':'mongo','collection':'country'}}");
-        JSONAssert.assertEquals(expected, x, false);
+    SecurityContext sc = new TestSecurityContext();
 
-        String expectedUpdateSchemaStatus = esc("{'entityInfo':{'name':'country','indexes':[{'name':null,'unique':true,'fields':[{'field':'name','dir':'$asc'}]},{'name': null,'unique': true,'fields': [{'field': '_id','dir': '$asc'}]}],'datastore':{'backend':'mongo','datasource':'mongo','collection':'country'}},'schema':{'name':'country','version':{'value':'1.0.0','changelog':'blahblah'},'status':{'value':'deprecated'},'access':{'insert':['anyone'],'update':['anyone'],'find':['anyone'],'delete':['anyone']},'fields':{'iso3code':{'type':'string'},'name':{'type':'string'},'iso2code':{'type':'string'},'objectType':{'type':'string','access':{'find':['anyone'],'update':['noone']},'constraints':{'required':true,'minLength':1}}}}}");
-        String resultUpdateSchemaStatus = cutMetadataResource.updateSchemaStatus(sc, "country", "1.0.0", "deprecated", "No comment");
-        JSONAssert.assertEquals(expectedUpdateSchemaStatus, resultUpdateSchemaStatus, false);
+    System.out.println("factory:" + RestConfiguration.getFactory());
+    String expectedCreated = readFile("expectedCreated.json");
+    String resultCreated = cutMetadataResource.createMetadata(sc, "country", "1.0.0",
+        readFile("resultCreated.json"));
+    JSONAssert.assertEquals(expectedCreated, resultCreated, false);
 
-    }
+    String expectedUpdateEntityInfo = readFile("expectedCreateSchema.json");
+    String resultUpdateEntityInfo = cutMetadataResource.createMetadata(sc, "country", "1.1.0",
+        expectedUpdateEntityInfo);
+    JSONAssert.assertEquals(expectedUpdateEntityInfo, resultUpdateEntityInfo, false);
+  }
 
-    @Test
-    public void createMetadataAlsoUpdates() throws Exception {
-        Assert.assertNotNull("MetadataResource was not injected by the container", cutMetadataResource);
+  @Test
+  public void diff() throws Exception {
+    Assert.assertNotNull("MetadataResource was not injected by the container", cutMetadataResource);
 
-        SecurityContext sc = new TestSecurityContext();
+    SecurityContext sc = new TestSecurityContext();
 
-        System.out.println("factory:" + RestConfiguration.getFactory());
-        String expectedCreated = readFile("expectedCreated.json");
-        String resultCreated = cutMetadataResource.createMetadata(sc, "country", "1.0.0", readFile("resultCreated.json"));
-        JSONAssert.assertEquals(expectedCreated, resultCreated, false);
+    System.out.println("factory:" + RestConfiguration.getFactory());
+    String expectedCreated = readFile("expectedCreated.json");
+    cutMetadataResource.createMetadata(sc, "country", "1.0.0", readFile("resultCreated.json"));
 
-        String expectedUpdateEntityInfo = readFile("expectedCreateSchema.json");
-        String resultUpdateEntityInfo = cutMetadataResource.createMetadata(sc, "country", "1.1.0", expectedUpdateEntityInfo);
-        JSONAssert.assertEquals(expectedUpdateEntityInfo, resultUpdateEntityInfo, false);
-    }
-    
-    @Test
-    public void diff() throws Exception {
-        Assert.assertNotNull("MetadataResource was not injected by the container", cutMetadataResource);
+    String expectedUpdateEntityInfo = readFile("expectedCreateSchema.json");
+    cutMetadataResource.createMetadata(sc, "country", "1.1.0", expectedUpdateEntityInfo);
 
-        SecurityContext sc = new TestSecurityContext();
+    String diff = cutMetadataResource.getDiff(sc, "country", "1.0.0", "1.1.0");
+    System.out.println("Diff:" + diff);
+    JSONAssert.assertEquals(
+        "[{\"-schema.version.value\":\"1.0.0\",\"+schema.version.value\":\"1.1.0\"},{\"+schema.fields.elementx\":{\"type\":\"string\",\"description\":null}},{\"-schema._id\":\"country|1.0.0\",\"+schema._id\":\"country|1.1.0\"}]]",
+        diff, false);
 
-        System.out.println("factory:" + RestConfiguration.getFactory());
-        String expectedCreated = readFile("expectedCreated.json");
-        cutMetadataResource.createMetadata(sc, "country", "1.0.0", readFile("resultCreated.json"));
 
-        String expectedUpdateEntityInfo = readFile("expectedCreateSchema.json");
-        cutMetadataResource.createMetadata(sc, "country", "1.1.0", expectedUpdateEntityInfo);
-
-        String diff=cutMetadataResource.getDiff(sc,"country","1.0.0","1.1.0");
-        System.out.println("Diff:"+diff);
-        JSONAssert.assertEquals("[{\"-schema.version.value\":\"1.0.0\",\"+schema.version.value\":\"1.1.0\"},{\"+schema.fields.elementx\":{\"type\":\"string\",\"description\":null}},{\"-schema._id\":\"country|1.0.0\",\"+schema._id\":\"country|1.1.0\"}]]",diff,false);
-
-                                   
-    }
+  }
 }

--- a/metadata/src/test/java/com/redhat/lightblue/rest/metadata/ITMongoIndexManipulationTest.java
+++ b/metadata/src/test/java/com/redhat/lightblue/rest/metadata/ITMongoIndexManipulationTest.java
@@ -18,6 +18,8 @@
  */
 package com.redhat.lightblue.rest.metadata;
 
+import static com.redhat.lightblue.util.test.FileUtil.readFile;
+
 import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
 import com.mongodb.DBCollection;
@@ -26,44 +28,44 @@ import com.mongodb.MongoClient;
 import com.redhat.lightblue.config.MetadataConfiguration;
 import com.redhat.lightblue.mongo.config.MongoConfiguration;
 import com.redhat.lightblue.mongo.metadata.MongoMetadata;
-import com.redhat.lightblue.mongo.test.EmbeddedMongo;
-import com.redhat.lightblue.rest.metadata.ITCaseMetadataResourceTest.FileStreamProcessor;
 import com.redhat.lightblue.rest.test.RestConfigurationRule;
 import com.redhat.lightblue.rest.test.support.Assets;
 import com.redhat.lightblue.rest.test.support.CrudWebXmls;
-import de.flapdoodle.embed.mongo.Command;
 import de.flapdoodle.embed.mongo.MongodExecutable;
 import de.flapdoodle.embed.mongo.MongodProcess;
 import de.flapdoodle.embed.mongo.MongodStarter;
 import de.flapdoodle.embed.mongo.config.Defaults;
 import de.flapdoodle.embed.mongo.config.MongodConfig;
 import de.flapdoodle.embed.mongo.config.Net;
+import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.mongo.packageresolver.Command;
 import de.flapdoodle.embed.process.config.RuntimeConfig;
-import de.flapdoodle.embed.process.config.io.ProcessOutput;
 import de.flapdoodle.embed.process.config.store.TimeoutConfig;
-import de.flapdoodle.embed.process.io.Processors;
-import de.flapdoodle.embed.process.io.StreamProcessor;
+import de.flapdoodle.embed.process.extract.DirectoryAndExecutableNaming;
+import de.flapdoodle.embed.process.extract.UserTempNaming;
+import de.flapdoodle.embed.process.io.directories.PlatformTempDir;
 import de.flapdoodle.embed.process.runtime.Network;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
+import de.flapdoodle.embed.process.store.Downloader;
+import de.flapdoodle.embed.process.store.ExtractedArtifactStore;
+import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Iterator;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.ws.rs.core.SecurityContext;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import javax.inject.Inject;
-import javax.ws.rs.core.SecurityContext;
-import java.io.File;
-import java.util.Iterator;
-import java.util.Map;
-
-import static com.redhat.lightblue.util.test.FileUtil.readFile;
 
 /**
  * Test to verify index creation in mongo backend through front-end API's.
@@ -73,390 +75,365 @@ import static com.redhat.lightblue.util.test.FileUtil.readFile;
 @RunWith(Arquillian.class)
 public class ITMongoIndexManipulationTest {
 
-    @Rule
-    public final RestConfigurationRule resetRuleConfiguration = new RestConfigurationRule();
+  @Rule
+  public final RestConfigurationRule resetRuleConfiguration = new RestConfigurationRule();
 
-    public static class FileStreamProcessor implements StreamProcessor {
-        private final FileOutputStream outputStream;
+  private static final String MONGO_HOST = "localhost";
+  private static final int MONGO_PORT = 27757;
+  private static final String IN_MEM_CONNECTION_URL = MONGO_HOST + ":" + MONGO_PORT;
 
-        public FileStreamProcessor(File file) throws FileNotFoundException {
-            outputStream = new FileOutputStream(file);
-        }
+  private static final String DB_NAME = "mongo";
 
+  private static MongodExecutable mongodExe;
+  private static MongodProcess mongod;
+  private static MongoClient mongo;
+  private static DB db;
+
+  static {
+    try {
+      RuntimeConfig runtimeConfig = Defaults.runtimeConfigFor(Command.MongoD)
+          .artifactStore(ExtractedArtifactStore.builder()
+              .extraction(DirectoryAndExecutableNaming.builder()
+                  .executableNaming(new UserTempNaming())
+                  .directory(new PlatformTempDir()).build())
+              .downloader(Downloader.platformDefault())
+              .temp(DirectoryAndExecutableNaming.builder()
+                  .executableNaming(new UserTempNaming())
+                  .directory(new PlatformTempDir()).build())
+              .downloadConfig(Defaults.downloadConfigFor(Command.MongoD)
+                  .timeoutConfig(TimeoutConfig.builder()
+                      .connectionTimeout((int) Duration.ofMinutes(1).toMillis())
+                      .readTimeout((int) Duration.ofMinutes(5).toMillis())
+                      .build())
+                  .fileNaming(new UserTempNaming()).build())
+              .build())
+          .build();
+
+      MongodStarter runtime = MongodStarter.getInstance(runtimeConfig);
+      mongodExe = runtime.prepare(
+          MongodConfig.builder()
+              .version(Version.V5_0_2)
+              .net(new Net(MONGO_PORT, Network.localhostIsIPv6()))
+              .build()
+      );
+      try {
+        mongod = mongodExe.start();
+      } catch (Throwable t) {
+        // try again, could be killed breakpoint in IDE
+        mongod = mongodExe.start();
+      }
+      mongo = new MongoClient(IN_MEM_CONNECTION_URL);
+
+      MongoConfiguration config = new MongoConfiguration();
+      // disable ssl for test (enabled by default)
+      config.setDatabase(DB_NAME);
+      config.setSsl(Boolean.FALSE);
+      config.addServerAddress(MONGO_HOST, MONGO_PORT);
+
+      db = config.getDB();
+
+      Runtime.getRuntime().addShutdownHook(new Thread() {
         @Override
-        public void process(String block) {
-            try {
-                outputStream.write(block.getBytes());
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
+        public void run() {
+          super.run();
+          clearDatabase();
         }
 
-        @Override
-        public void onProcessed() {
-            try {
-                outputStream.close();
-            } catch (IOException e) {
-                throw new IllegalStateException(e);
-            }
-        }
-
+      });
+    } catch (IOException e) {
+      throw new java.lang.Error(e);
     }
+  }
 
-    private static final String MONGO_HOST = "localhost";
-    private static final int MONGO_PORT = 27757;
-    private static final String IN_MEM_CONNECTION_URL = MONGO_HOST + ":" + MONGO_PORT;
+  @Before
+  public void setup() {
+    db.createCollection(MongoMetadata.DEFAULT_METADATA_COLLECTION, null);
+    BasicDBObject index = new BasicDBObject("name", 1);
+    index.put("version.value", 1);
+    db.getCollection(MongoMetadata.DEFAULT_METADATA_COLLECTION).createIndex(index, "name", true);
+    db.createCollection("test", null);
+  }
 
-    private static final String DB_NAME = "mongo";
-
-    private static MongodExecutable mongodExe;
-    private static MongodProcess mongod;
-    private static MongoClient mongo;
-    private static DB db;
-
-    static {
-        try {
-            StreamProcessor mongodOutput = Processors.named("[mongod>]",
-                new ITCaseMetadataResourceTest.FileStreamProcessor(File.createTempFile("mongod", "log")));
-            StreamProcessor mongodError = new ITCaseMetadataResourceTest.FileStreamProcessor(File.createTempFile("mongod-error", "log"));
-            StreamProcessor commandsOutput = Processors.namedConsole("[console>]");
-
-            Command mongoD = Command.MongoD;
-            RuntimeConfig runtimeConfig = Defaults.runtimeConfigFor(mongoD)
-                .processOutput(new ProcessOutput(mongodOutput, mongodError, commandsOutput))
-                .artifactStore(Defaults.extractedArtifactStoreFor(mongoD)
-                    .withDownloadConfig(Defaults.downloadConfigFor(mongoD)
-                        .timeoutConfig(TimeoutConfig.builder()
-                            .connectionTimeout((int) Duration.ofMinutes(1).toMillis())
-                            .readTimeout((int) Duration.ofMinutes(5).toMillis())
-                            .build()).build()))
-                .build();
-
-            MongodStarter runtime = MongodStarter.getInstance(runtimeConfig);
-            mongodExe = runtime.prepare(
-                MongodConfig.builder()
-                    .version(de.flapdoodle.embed.mongo.distribution.Version.V3_1_6)
-                    .net(new Net(MONGO_PORT, Network.localhostIsIPv6()))
-                    .build()
-            );
-            try {
-                mongod = mongodExe.start();
-            } catch (Throwable t) {
-                // try again, could be killed breakpoint in IDE
-                mongod = mongodExe.start();
-            }
-            MongoClient mongoClient = new MongoClient(IN_MEM_CONNECTION_URL);
-            mongo = mongoClient;
-
-            MongoConfiguration config = new MongoConfiguration();
-            // disable ssl for test (enabled by default)
-            config.setDatabase(DB_NAME);
-            config.setSsl(Boolean.FALSE);
-            config.addServerAddress(MONGO_HOST, MONGO_PORT);
-
-            db = config.getDB();
-
-            Runtime.getRuntime().addShutdownHook(new Thread() {
-                @Override
-                public void run() {
-                    super.run();
-                    clearDatabase();
-                }
-
-            });
-        } catch (IOException e) {
-            throw new java.lang.Error(e);
-        }
+  @After
+  public void teardown() {
+    if (mongo != null) {
+      mongo.dropDatabase(DB_NAME);
     }
+  }
 
-    @Before
-    public void setup() throws Exception {
-        db.createCollection(MongoMetadata.DEFAULT_METADATA_COLLECTION, null);
-        BasicDBObject index = new BasicDBObject("name", 1);
-        index.put("version.value", 1);
-        db.getCollection(MongoMetadata.DEFAULT_METADATA_COLLECTION).createIndex(index, "name", true);
-        db.createCollection("test", null);
+  public static void clearDatabase() {
+    if (mongod != null) {
+      mongod.stop();
+      mongodExe.stop();
     }
+    db = null;
+    mongo = null;
+    mongod = null;
+    mongodExe = null;
+  }
 
-    @After
-    public void teardown() {
-        if (mongo != null) {
-            mongo.dropDatabase(DB_NAME);
-        }
+  @Deployment
+  public static WebArchive createDeployment() throws Exception {
+    File[] libs = Maven.resolver().loadPomFromFile("pom.xml").importRuntimeDependencies().resolve()
+        .withTransitivity().asFile();
+
+    WebArchive archive = ShrinkWrap.create(WebArchive.class, "lightblue.war")
+        .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+        .addAsWebInfResource(
+            Assets.forDocument(CrudWebXmls.forNonEE6Container(RestApplication.class)), "web.xml")
+        .addAsLibraries(Maven.configureResolver()
+            .workOffline()
+            .loadPomFromFile("pom.xml")
+            .resolve("org.jboss.weld.servlet:weld-servlet")
+            .withTransitivity()
+            .asFile())
+        .addPackages(true, "com.redhat.lightblue")
+        .addAsResource(new File("src/test/resources/lightblue-metadata.json"),
+            MetadataConfiguration.FILENAME)
+        .addAsResource(new File("src/test/resources/datasources.json"), "datasources.json")
+        .addAsResource(EmptyAsset.INSTANCE, "resources/test.properties");
+
+    for (File file : libs) {
+      archive.addAsLibrary(file);
     }
+    return archive;
+  }
 
-    public static void clearDatabase() {
-        if (mongod != null) {
-            mongod.stop();
-            mongodExe.stop();
-        }
-        db = null;
-        mongo = null;
-        mongod = null;
-        mongodExe = null;
+  @Inject
+  private AbstractMetadataResource metadataResource;
+
+  @Test
+  public void createWithSimpleIndex() throws Exception {
+    String metadata = readFile(getClass().getSimpleName() + "-createWithSimpleIndex-metadata.json");
+    String entityName = "test";
+    String entityVersion = "1.0.0";
+    SecurityContext sc = new TestSecurityContext();
+
+    Assert.assertNotNull(metadata);
+    Assert.assertTrue(metadata.length() > 0);
+
+    // create metadata without any non-default indexes
+    metadataResource.createMetadata(sc, entityName, entityVersion, metadata);
+
+    DBCollection metadataCollection = mongo.getDB(DB_NAME).getCollection("metadata");
+    Assert.assertTrue("Metadata was not created!", 2 <= metadataCollection.find().count());
+
+    DBCollection entityCollection = mongo.getDB(DB_NAME).getCollection(entityName);
+
+    // verify has _id and field1 index by simply check on index count
+    Assert.assertEquals("indexes not created", 2, entityCollection.getIndexInfo().size());
+  }
+
+  @Test
+  public void addSimpleIndex_forced() throws Exception {
+    String metadata = readFile(getClass().getSimpleName() + "-addSimpleIndex-metadata.json");
+    String entityName = "test";
+    String entityVersion = "1.0.0";
+    SecurityContext sc = new TestSecurityContext();
+
+    Assert.assertNotNull(metadata);
+    Assert.assertTrue(metadata.length() > 0);
+
+    // create metadata without any non-default indexes
+    metadataResource.createMetadata(sc, entityName, entityVersion, metadata);
+
+    DBCollection metadataCollection = mongo.getDB(DB_NAME).getCollection("metadata");
+    Assert.assertTrue("Metadata was not created!", 2 <= metadataCollection.find().count());
+
+    DBCollection entityCollection = mongo.getDB(DB_NAME).getCollection(entityName);
+
+    Assert.assertEquals("expected no indexes", 0, entityCollection.getIndexInfo().size());
+
+    entityCollection.createIndex(new BasicDBObject("x", 1));
+
+    // since index was forced the collection is initialized and we don't need to create a dummy doc
+    Assert.assertEquals("indexes not created", 2, entityCollection.getIndexInfo().size());
+  }
+
+  @Test
+  public void addSimpleIndex() throws Exception {
+    String metadata = readFile(getClass().getSimpleName() + "-addSimpleIndex-metadata.json");
+    String entityInfo = readFile(getClass().getSimpleName() + "-addSimpleIndex-entityInfo.json");
+    String entityName = "test";
+    String entityVersion = "1.0.0";
+    SecurityContext sc = new TestSecurityContext();
+
+    Assert.assertNotNull(metadata);
+    Assert.assertTrue(metadata.length() > 0);
+
+    // create metadata without any non-default indexes
+    metadataResource.createMetadata(sc, entityName, entityVersion, metadata);
+
+    DBCollection metadataCollection = mongo.getDB(DB_NAME).getCollection("metadata");
+    Assert.assertTrue("Metadata was not created!", 2 <= metadataCollection.find().count());
+
+    DBCollection entityCollection = mongo.getDB(DB_NAME).getCollection(entityName);
+
+    // verify no indexes, since collection hasn't been touched yet (no indexes, no data)
+    Assert.assertEquals("expected no indexes", 0, entityCollection.getIndexInfo().size());
+
+    // update entityInfo to add an index
+    metadataResource.updateEntityInfo(sc, entityName, entityInfo);
+
+    // verify has _id and field1 index by simply check on index count
+    Assert.assertEquals("indexes not created", 2, entityCollection.getIndexInfo().size());
+  }
+
+  @Test
+
+  public void deleteSimpleIndex() throws Exception {
+    String metadata = readFile(getClass().getSimpleName() + "-deleteSimpleIndex-metadata.json");
+    String entityInfo = readFile(getClass().getSimpleName() + "-deleteSimpleIndex-entityInfo.json");
+    String entityName = "test";
+    String entityVersion = "1.0.0";
+    SecurityContext sc = new TestSecurityContext();
+
+    Assert.assertNotNull(metadata);
+    Assert.assertTrue(metadata.length() > 0);
+
+    // create metadata with one non-default index
+    metadataResource.createMetadata(sc, entityName, entityVersion, metadata);
+
+    DBCollection metadataCollection = mongo.getDB(DB_NAME).getCollection("metadata");
+    Assert.assertTrue("Metadata was not created!", 2 <= metadataCollection.find().count());
+
+    DBCollection entityCollection = mongo.getDB(DB_NAME).getCollection(entityName);
+
+    // verify no indexes, since collection hasn't been touched yet (no indexes, no data)
+    Assert.assertEquals("indexes not created", 2, entityCollection.getIndexInfo().size());
+
+    // update entityInfo to remove index
+    metadataResource.updateEntityInfo(sc, entityName, entityInfo);
+
+    // verify has _id and field1 index by simply check on index count
+    Assert.assertEquals("index not deleted", 1, entityCollection.getIndexInfo().size());
+  }
+
+  @Test
+
+  public void createWithArrayIndex() throws Exception {
+    String metadata = readFile(getClass().getSimpleName() + "-createWithArrayIndex-metadata.json");
+    String entityName = "test";
+    String entityVersion = "1.0.0";
+    SecurityContext sc = new TestSecurityContext();
+
+    Assert.assertNotNull(metadata);
+    Assert.assertTrue(metadata.length() > 0);
+
+    // create metadata without any non-default indexes
+    metadataResource.createMetadata(sc, entityName, entityVersion, metadata);
+
+    DBCollection metadataCollection = mongo.getDB(DB_NAME).getCollection("metadata");
+    Assert.assertTrue("Metadata was not created!", 2 <= metadataCollection.find().count());
+
+    DBCollection entityCollection = mongo.getDB(DB_NAME).getCollection(entityName);
+
+    // verify has _id and field1 index by simply check on index count
+    Assert.assertEquals("indexes not created", 2, entityCollection.getIndexInfo().size());
+  }
+
+  @Test
+
+  public void addArrayIndex() throws Exception {
+    String metadata = readFile(getClass().getSimpleName() + "-addArrayIndex-metadata.json");
+    String entityInfo = readFile(getClass().getSimpleName() + "-addArrayIndex-entityInfo.json");
+    String entityName = "test";
+    String entityVersion = "1.0.0";
+    SecurityContext sc = new TestSecurityContext();
+
+    Assert.assertNotNull(metadata);
+    Assert.assertTrue(metadata.length() > 0);
+
+    // create metadata without any non-default indexes
+    metadataResource.createMetadata(sc, entityName, entityVersion, metadata);
+
+    DBCollection metadataCollection = mongo.getDB(DB_NAME).getCollection("metadata");
+    Assert.assertTrue("Metadata was not created!", 2 <= metadataCollection.find().count());
+
+    DBCollection entityCollection = mongo.getDB(DB_NAME).getCollection(entityName);
+
+    // verify no indexes, since collection hasn't been touched yet (no indexes, no data)
+    Assert.assertEquals("expected no indexes", 0, entityCollection.getIndexInfo().size());
+
+    // update entityInfo to add an index
+    metadataResource.updateEntityInfo(sc, entityName, entityInfo);
+
+    // verify has _id and field1 index by simply check on index count
+    Assert.assertEquals("indexes not created", 2, entityCollection.getIndexInfo().size());
+  }
+
+  @Test
+
+  public void esbMessage() throws Exception {
+    String metadata = readFile(getClass().getSimpleName() + "-esbMessage-metadata.json");
+    String entityInfo = readFile(getClass().getSimpleName() + "-esbMessage-entityInfo.json");
+    String entityName = "test";
+    String entityVersion = "0.4.0-SNAPSHOT";
+    SecurityContext sc = new TestSecurityContext();
+
+    Assert.assertNotNull(metadata);
+    Assert.assertTrue(metadata.length() > 0);
+
+    // create metadata without any non-default indexes
+    metadataResource.createMetadata(sc, entityName, entityVersion, metadata);
+
+    DBCollection metadataCollection = mongo.getDB(DB_NAME).getCollection("metadata");
+    Assert.assertTrue("Metadata was not created!", 2 <= metadataCollection.find().count());
+
+    DBCollection entityCollection = mongo.getDB(DB_NAME).getCollection(entityName);
+
+    // verify no indexes, since collection hasn't been touched yet (no indexes, no data)
+    Assert.assertEquals("expected no indexes", 0, entityCollection.getIndexInfo().size());
+
+    // update entityInfo to add an index
+    metadataResource.updateEntityInfo(sc, entityName, entityInfo);
+
+    // verify has _id and field1 index by simply check on index count
+    Assert.assertEquals("indexes not created", 2, entityCollection.getIndexInfo().size());
+
+    // verify specific index
+    boolean verified = false;
+    for (DBObject dbi : entityCollection.getIndexInfo()) {
+      if (((BasicDBObject) dbi.get("key")).entrySet().iterator().next().getKey().equals("_id")) {
+        continue;
+      }
+      // non _id index is the one we want to verify with
+      Iterator<Map.Entry<String, Object>> i = ((BasicDBObject) dbi.get("key")).entrySet()
+          .iterator();
+      Assert.assertEquals("esbMessageSearchable.value", i.next().getKey());
+      Assert.assertEquals("esbMessageSearchable.path", i.next().getKey());
+      verified = true;
     }
+    Assert.assertTrue(verified);
+  }
 
-    @Deployment
-    public static WebArchive createDeployment() throws Exception {
-        File[] libs = Maven.resolver().loadPomFromFile("pom.xml").importRuntimeDependencies().resolve().withTransitivity().asFile();
+  @Test
 
-        WebArchive archive = ShrinkWrap.create(WebArchive.class, "lightblue.war")
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-                .addAsWebInfResource(Assets.forDocument(CrudWebXmls.forNonEE6Container(RestApplication.class)), "web.xml")
-                .addAsLibraries(Maven.configureResolver()
-                        .workOffline()
-                        .loadPomFromFile("pom.xml")
-                        .resolve("org.jboss.weld.servlet:weld-servlet")
-                        .withTransitivity()
-                        .asFile())
-                .addPackages(true, "com.redhat.lightblue")
-                .addAsResource(new File("src/test/resources/lightblue-metadata.json"), MetadataConfiguration.FILENAME)
-                .addAsResource(new File("src/test/resources/datasources.json"), "datasources.json")
-                .addAsResource(EmptyAsset.INSTANCE, "resources/test.properties");
+  public void deleteArrayIndex() throws Exception {
+    String metadata = readFile(getClass().getSimpleName() + "-deleteArrayIndex-metadata.json");
+    String entityInfo = readFile(getClass().getSimpleName() + "-deleteArrayIndex-entityInfo.json");
+    String entityName = "test";
+    String entityVersion = "1.0.0";
+    SecurityContext sc = new TestSecurityContext();
 
-        for (File file : libs) {
-            archive.addAsLibrary(file);
-        }
-        return archive;
-    }
+    Assert.assertNotNull(metadata);
+    Assert.assertTrue(metadata.length() > 0);
 
-    @Inject
-    private AbstractMetadataResource metadataResource;
+    // create metadata without any non-default indexes
+    metadataResource.createMetadata(sc, entityName, entityVersion, metadata);
 
-    @Test
-    
-    public void createWithSimpleIndex() throws Exception {
-        String metadata = readFile(getClass().getSimpleName() + "-createWithSimpleIndex-metadata.json");
-        String entityName = "test";
-        String entityVersion = "1.0.0";
-        SecurityContext sc = new TestSecurityContext();
+    DBCollection metadataCollection = mongo.getDB(DB_NAME).getCollection("metadata");
+    Assert.assertTrue("Metadata was not created!", 2 <= metadataCollection.find().count());
 
-        Assert.assertNotNull(metadata);
-        Assert.assertTrue(metadata.length() > 0);
+    DBCollection entityCollection = mongo.getDB(DB_NAME).getCollection(entityName);
 
-        // create metadata without any non-default indexes
-        metadataResource.createMetadata(sc, entityName, entityVersion, metadata);
+    // verify no indexes, since collection hasn't been touched yet (no indexes, no data)
+    Assert.assertEquals("indexes not created", 2, entityCollection.getIndexInfo().size());
 
-        DBCollection metadataCollection = mongo.getDB(DB_NAME).getCollection("metadata");
-        Assert.assertTrue("Metadata was not created!", 2 <= metadataCollection.find().count());
+    // update entityInfo to delete an index
+    metadataResource.updateEntityInfo(sc, entityName, entityInfo);
 
-        DBCollection entityCollection = mongo.getDB(DB_NAME).getCollection(entityName);
-
-        // verify has _id and field1 index by simply check on index count
-        Assert.assertEquals("indexes not created", 2, entityCollection.getIndexInfo().size());
-    }
-
-    @Test
-    
-    public void addSimpleIndex_forced() throws Exception {
-        String metadata = readFile(getClass().getSimpleName() + "-addSimpleIndex-metadata.json");
-        String entityName = "test";
-        String entityVersion = "1.0.0";
-        SecurityContext sc = new TestSecurityContext();
-
-        Assert.assertNotNull(metadata);
-        Assert.assertTrue(metadata.length() > 0);
-
-        // create metadata without any non-default indexes
-        metadataResource.createMetadata(sc, entityName, entityVersion, metadata);
-
-        DBCollection metadataCollection = mongo.getDB(DB_NAME).getCollection("metadata");
-        Assert.assertTrue("Metadata was not created!", 2 <= metadataCollection.find().count());
-
-        DBCollection entityCollection = mongo.getDB(DB_NAME).getCollection(entityName);
-
-        Assert.assertEquals("expected no indexes", 0, entityCollection.getIndexInfo().size());
-
-        entityCollection.createIndex(new BasicDBObject("x", 1));
-
-        // since index was forced the collection is initialized and we don't need to create a dummy doc
-        Assert.assertEquals("indexes not created", 2, entityCollection.getIndexInfo().size());
-    }
-
-    @Test
-    
-    public void addSimpleIndex() throws Exception {
-        String metadata = readFile(getClass().getSimpleName() + "-addSimpleIndex-metadata.json");
-        String entityInfo = readFile(getClass().getSimpleName() + "-addSimpleIndex-entityInfo.json");
-        String entityName = "test";
-        String entityVersion = "1.0.0";
-        SecurityContext sc = new TestSecurityContext();
-
-        Assert.assertNotNull(metadata);
-        Assert.assertTrue(metadata.length() > 0);
-
-        // create metadata without any non-default indexes
-        metadataResource.createMetadata(sc, entityName, entityVersion, metadata);
-
-        DBCollection metadataCollection = mongo.getDB(DB_NAME).getCollection("metadata");
-        Assert.assertTrue("Metadata was not created!", 2 <= metadataCollection.find().count());
-
-        DBCollection entityCollection = mongo.getDB(DB_NAME).getCollection(entityName);
-
-        // verify no indexes, since collection hasn't been touched yet (no indexes, no data)
-        Assert.assertEquals("expected no indexes", 0, entityCollection.getIndexInfo().size());
-
-        // update entityInfo to add an index
-        metadataResource.updateEntityInfo(sc, entityName, entityInfo);
-
-        // verify has _id and field1 index by simply check on index count
-        Assert.assertEquals("indexes not created", 2, entityCollection.getIndexInfo().size());
-    }
-
-    @Test
-    
-    public void deleteSimpleIndex() throws Exception {
-        String metadata = readFile(getClass().getSimpleName() + "-deleteSimpleIndex-metadata.json");
-        String entityInfo = readFile(getClass().getSimpleName() + "-deleteSimpleIndex-entityInfo.json");
-        String entityName = "test";
-        String entityVersion = "1.0.0";
-        SecurityContext sc = new TestSecurityContext();
-
-        Assert.assertNotNull(metadata);
-        Assert.assertTrue(metadata.length() > 0);
-
-        // create metadata with one non-default index
-        metadataResource.createMetadata(sc, entityName, entityVersion, metadata);
-
-        DBCollection metadataCollection = mongo.getDB(DB_NAME).getCollection("metadata");
-        Assert.assertTrue("Metadata was not created!", 2 <= metadataCollection.find().count());
-
-        DBCollection entityCollection = mongo.getDB(DB_NAME).getCollection(entityName);
-
-        // verify no indexes, since collection hasn't been touched yet (no indexes, no data)
-        Assert.assertEquals("indexes not created", 2, entityCollection.getIndexInfo().size());
-
-        // update entityInfo to remove index
-        metadataResource.updateEntityInfo(sc, entityName, entityInfo);
-
-        // verify has _id and field1 index by simply check on index count
-        Assert.assertEquals("index not deleted", 1, entityCollection.getIndexInfo().size());
-    }
-
-    @Test
-    
-    public void createWithArrayIndex() throws Exception {
-        String metadata = readFile(getClass().getSimpleName() + "-createWithArrayIndex-metadata.json");
-        String entityName = "test";
-        String entityVersion = "1.0.0";
-        SecurityContext sc = new TestSecurityContext();
-
-        Assert.assertNotNull(metadata);
-        Assert.assertTrue(metadata.length() > 0);
-
-        // create metadata without any non-default indexes
-        metadataResource.createMetadata(sc, entityName, entityVersion, metadata);
-
-        DBCollection metadataCollection = mongo.getDB(DB_NAME).getCollection("metadata");
-        Assert.assertTrue("Metadata was not created!", 2 <= metadataCollection.find().count());
-
-        DBCollection entityCollection = mongo.getDB(DB_NAME).getCollection(entityName);
-
-        // verify has _id and field1 index by simply check on index count
-        Assert.assertEquals("indexes not created", 2, entityCollection.getIndexInfo().size());
-    }
-
-    @Test
-    
-    public void addArrayIndex() throws Exception {
-        String metadata = readFile(getClass().getSimpleName() + "-addArrayIndex-metadata.json");
-        String entityInfo = readFile(getClass().getSimpleName() + "-addArrayIndex-entityInfo.json");
-        String entityName = "test";
-        String entityVersion = "1.0.0";
-        SecurityContext sc = new TestSecurityContext();
-
-        Assert.assertNotNull(metadata);
-        Assert.assertTrue(metadata.length() > 0);
-
-        // create metadata without any non-default indexes
-        metadataResource.createMetadata(sc, entityName, entityVersion, metadata);
-
-        DBCollection metadataCollection = mongo.getDB(DB_NAME).getCollection("metadata");
-        Assert.assertTrue("Metadata was not created!", 2 <= metadataCollection.find().count());
-
-        DBCollection entityCollection = mongo.getDB(DB_NAME).getCollection(entityName);
-
-        // verify no indexes, since collection hasn't been touched yet (no indexes, no data)
-        Assert.assertEquals("expected no indexes", 0, entityCollection.getIndexInfo().size());
-
-        // update entityInfo to add an index
-        metadataResource.updateEntityInfo(sc, entityName, entityInfo);
-
-        // verify has _id and field1 index by simply check on index count
-        Assert.assertEquals("indexes not created", 2, entityCollection.getIndexInfo().size());
-    }
-
-    @Test
-    
-    public void esbMessage() throws Exception {
-        String metadata = readFile(getClass().getSimpleName() + "-esbMessage-metadata.json");
-        String entityInfo = readFile(getClass().getSimpleName() + "-esbMessage-entityInfo.json");
-        String entityName = "test";
-        String entityVersion = "0.4.0-SNAPSHOT";
-        SecurityContext sc = new TestSecurityContext();
-
-        Assert.assertNotNull(metadata);
-        Assert.assertTrue(metadata.length() > 0);
-
-        // create metadata without any non-default indexes
-        metadataResource.createMetadata(sc, entityName, entityVersion, metadata);
-
-        DBCollection metadataCollection = mongo.getDB(DB_NAME).getCollection("metadata");
-        Assert.assertTrue("Metadata was not created!", 2 <= metadataCollection.find().count());
-
-        DBCollection entityCollection = mongo.getDB(DB_NAME).getCollection(entityName);
-
-        // verify no indexes, since collection hasn't been touched yet (no indexes, no data)
-        Assert.assertEquals("expected no indexes", 0, entityCollection.getIndexInfo().size());
-
-        // update entityInfo to add an index
-        metadataResource.updateEntityInfo(sc, entityName, entityInfo);
-
-        // verify has _id and field1 index by simply check on index count
-        Assert.assertEquals("indexes not created", 2, entityCollection.getIndexInfo().size());
-
-        // verify specific index
-        boolean verified = false;
-        for (DBObject dbi : entityCollection.getIndexInfo()) {
-            if (((BasicDBObject) dbi.get("key")).entrySet().iterator().next().getKey().equals("_id")) {
-                continue;
-            }
-            // non _id index is the one we want to verify with
-            Iterator<Map.Entry<String, Object>> i = ((BasicDBObject) dbi.get("key")).entrySet().iterator();
-            Assert.assertEquals("esbMessageSearchable.value", i.next().getKey());
-            Assert.assertEquals("esbMessageSearchable.path", i.next().getKey());
-            verified = true;
-        }
-        Assert.assertTrue(verified);
-    }
-
-    @Test
-    
-    public void deleteArrayIndex() throws Exception {
-        String metadata = readFile(getClass().getSimpleName() + "-deleteArrayIndex-metadata.json");
-        String entityInfo = readFile(getClass().getSimpleName() + "-deleteArrayIndex-entityInfo.json");
-        String entityName = "test";
-        String entityVersion = "1.0.0";
-        SecurityContext sc = new TestSecurityContext();
-
-        Assert.assertNotNull(metadata);
-        Assert.assertTrue(metadata.length() > 0);
-
-        // create metadata without any non-default indexes
-        metadataResource.createMetadata(sc, entityName, entityVersion, metadata);
-
-        DBCollection metadataCollection = mongo.getDB(DB_NAME).getCollection("metadata");
-        Assert.assertTrue("Metadata was not created!", 2 <= metadataCollection.find().count());
-
-        DBCollection entityCollection = mongo.getDB(DB_NAME).getCollection(entityName);
-
-        // verify no indexes, since collection hasn't been touched yet (no indexes, no data)
-        Assert.assertEquals("indexes not created", 2, entityCollection.getIndexInfo().size());
-
-        // update entityInfo to delete an index
-        metadataResource.updateEntityInfo(sc, entityName, entityInfo);
-
-        // verify has _id and field1 index by simply check on index count
-        Assert.assertEquals("index not deleted", 1, entityCollection.getIndexInfo().size());
-    }
+    // verify has _id and field1 index by simply check on index count
+    Assert.assertEquals("index not deleted", 1, entityCollection.getIndexInfo().size());
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -360,7 +360,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses />.
         <lightblue.mongo.version>1.37.0-SNAPSHOT</lightblue.mongo.version>
         <lightblue.ldap.version>1.11.0</lightblue.ldap.version>
         <lightblue.audithook.version>1.10.0</lightblue.audithook.version>
-        <lightblue.notificationhook.version>0.1.4</lightblue.notificationhook.version>
+        <lightblue.notificationhook.version>0.1.5-SNAPSHOT</lightblue.notificationhook.version>
         <dropwizard.metrics.version>3.2.2</dropwizard.metrics.version>
     </properties>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses />.
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <version>4.13.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
Lightblue-mongo was upgraded to latest version of flapdoodle that also impacts lightblue-rest and other lightblue libraries.

* Upgrade to flapdoodle 3.4.7
* Fix test failures and flapdoodle configuration specific to lightblue-rest
* Fix few SONAR issues on the files that required changes 

